### PR TITLE
Fix issue with lifetime elision

### DIFF
--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -91,7 +91,7 @@ impl<'a> Client<'a> {
     }
 
     /// Get back all extensions.
-    pub fn drain_extensions(&mut self) -> impl Iterator<Item = Box<dyn Extension + Send>> {
+    pub fn drain_extensions(&mut self) -> impl Iterator<Item = Box<dyn Extension + Send>> + '_ {
         self.extensions.drain()
     }
 }
@@ -280,7 +280,7 @@ impl<'a> Server<'a> {
     }
 
     /// Get back all extensions.
-    pub fn drain_extensions(&mut self) -> impl Iterator<Item = Box<dyn Extension + Send>> {
+    pub fn drain_extensions(&mut self) -> impl Iterator<Item = Box<dyn Extension + Send>> + '_ {
         self.extensions.drain()
     }
 }


### PR DESCRIPTION
Hello, according to https://github.com/rust-lang/rust/pull/63376 , the compiler used to accept the current function signature of `drain_extensions()` by mistake. The compiler will soon fix this (when the above said PR lands), and after that the current code won't compile.

This PR fixes the code. Please note that the latest published version soketto-0.2.2 contains this error too.
