### PR TITLE
Support sending PINGs and receiving PONGs.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,5 +36,5 @@ thiserror = "1.0"
 
 [dev-dependencies]
 assert_matches = "1.3"
-async-std = "1.0"
+async-std = "1.1"
 quickcheck = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ sha1 = "0.6"
 smallvec = "1.0"
 static_assertions = "1.0"
 thiserror = "1.0"
+typenum = "1.11"
 
 [dev-dependencies]
 assert_matches = "1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,8 @@ log = "0.4.8"
 rand = "0.7"
 sha1 = "0.6"
 smallvec = "1.0"
-static_assertions = "1.0"
+static_assertions = "1.1"
 thiserror = "1.0"
-typenum = "1.11"
 
 [dev-dependencies]
 assert_matches = "1.3"

--- a/src/base.rs
+++ b/src/base.rs
@@ -24,7 +24,7 @@ use std::{convert::TryFrom, fmt, io};
 pub(crate) const MAX_HEADER_SIZE: usize = 14;
 
 /// Max. size of a control frame payload.
-const MAX_CTRL_BODY_SIZE: u64 = 125;
+pub(crate) const MAX_CTRL_BODY_SIZE: u64 = 125;
 
 // OpCode /////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -408,6 +408,10 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Sender<T> {
                 let mut header = Header::new(OpCode::Ping);
                 self.send_frame(&mut header, ping).await
             }
+            pong @ Outgoing::Pong(_) => {
+                let mut header = Header::new(OpCode::Pong);
+                self.send_frame(&mut header, pong).await
+            }
             Outgoing::Data(d) => self.send_data(d).await
         }
     }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -6,10 +6,12 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
-//! A persistent websocket connection after the handshake phase.
+//! A persistent websocket connection after the handshake phase, represented
+//! as a [`Sender`] and [`Receiver`] pair.
 
 use bytes::{BufMut, BytesMut};
 use crate::{Parsing, base::{self, Header, MAX_HEADER_SIZE, OpCode}, extension::Extension};
+use crate::data::{Data, Incoming, Outgoing};
 use futures::{io::{BufWriter, ReadHalf, WriteHalf}, lock::BiLock, prelude::*, stream};
 use smallvec::SmallVec;
 use static_assertions::const_assert;
@@ -89,6 +91,13 @@ pub struct Builder<T> {
 
 impl<T: AsyncRead + AsyncWrite + Unpin> Builder<T> {
     /// Create a new `Builder` from the given async I/O resource and mode.
+    ///
+    /// **Note**: Use this type only after a successful handshake
+    /// (cf. [`Client::into_builder`][1] and [`Server::into_builder`][2]
+    /// for examples).
+    ///
+    /// [1]: crate::handshake::Client::into_builder
+    /// [2]: crate::handshake::Server::into_builder
     pub fn new(socket: T, mode: Mode) -> Self {
         let mut codec = base::Codec::default();
         codec.set_max_data_size(MAX_FRAME_SIZE);
@@ -183,10 +192,9 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Receiver<T> {
     /// Receive the next websocket message.
     ///
     /// Fragmented messages will be concatenated and returned as one block.
-    /// The `bool` indicates if the data is textual (`true`) or binary
-    /// (`false`). If `Connection::validate_utf8` is `true` textual data
+    /// Unless `Builder::validate_utf8` was applied to `false` textual data
     /// is checked for well-formed UTF-8 encoding before returned.
-    pub async fn receive(&mut self) -> Result<(BytesMut, bool), Error> {
+    pub async fn receive(&mut self) -> Result<Incoming, Error> {
         let mut first_fragment_opcode = None;
         loop {
             if self.is_closed {
@@ -202,6 +210,9 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Receiver<T> {
                 self.read_buffer(&header).await?;
                 let mut data = self.buffer.split_to(header.payload_len());
                 base::Codec::apply_mask(&header, &mut data);
+                if header.opcode() == OpCode::Pong {
+                    return Ok(Incoming::Pong(data))
+                }
                 self.on_control(&header, &mut data).await?;
                 continue
             }
@@ -256,13 +267,27 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Receiver<T> {
                 }
             }
 
-            let is_text = header.opcode() == OpCode::Text;
-
-            if is_text && self.validate_utf8 {
-                std::str::from_utf8(&self.message)?;
+            if header.opcode() == OpCode::Text {
+                if self.validate_utf8 {
+                    std::str::from_utf8(&self.message)?;
+                }
+                return Ok(Data::Text(self.message.take()).into())
             }
 
-            return Ok((self.message.take(), is_text))
+            return Ok(Data::Binary(self.message.take()).into())
+        }
+    }
+
+    /// Receive the next websocket message, skipping over control frames.
+    ///
+    /// Fragmented messages will be concatenated and returned as one block.
+    /// Unless `Builder::validate_utf8` was applied to `false` textual data
+    /// is checked for well-formed UTF-8 encoding before returned.
+    pub async fn receive_data(&mut self) -> Result<Data, Error> {
+        loop {
+            if let Incoming::Data(d) = self.receive().await? {
+                return Ok(d)
+            }
         }
     }
 
@@ -376,18 +401,28 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Receiver<T> {
 }
 
 impl<T: AsyncRead + AsyncWrite + Unpin> Sender<T> {
-    /// Send some binary data over this connection.
-    pub async fn send_binary(&mut self, data: impl Into<BytesMut>) -> Result<(), Error> {
-        let mut header = Header::new(OpCode::Binary);
-        self.send(&mut header, data.into()).await
+    /// Send some data or ping over this connection.
+    pub async fn send(&mut self, outgoing: Outgoing) -> Result<(), Error> {
+        match outgoing {
+            ping @ Outgoing::Ping(_) => {
+                let mut header = Header::new(OpCode::Ping);
+                self.send_frame(&mut header, ping).await
+            }
+            Outgoing::Data(d) => self.send_data(d).await
+        }
     }
 
-    /// Send some text data over this connection.
-    pub async fn send_text(&mut self, data: impl Into<BytesMut>) -> Result<(), Error> {
-        let bytes = data.into();
-        debug_assert!(std::str::from_utf8(&bytes).is_ok());
-        let mut header = Header::new(OpCode::Text);
-        self.send(&mut header, bytes).await
+    /// Send some data over this connection.
+    pub async fn send_data(&mut self, data: impl Into<Data>) -> Result<(), Error> {
+        let data = data.into();
+        let mut header = match &data {
+            Data::Binary(_) => Header::new(OpCode::Binary),
+            Data::Text(_) => {
+                debug_assert!(std::str::from_utf8(data.as_ref()).is_ok());
+                Header::new(OpCode::Text)
+            }
+        };
+        self.send_frame(&mut header, data.into()).await
     }
 
     /// Flush the socket buffer.
@@ -409,15 +444,15 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Sender<T> {
     /// Send arbitrary websocket frames.
     ///
     /// Before sending, extensions will be applied to header and payload data.
-    async fn send(&mut self, header: &mut Header, mut data: BytesMut) -> Result<(), Error> {
+    async fn send_frame(&mut self, header: &mut Header, mut data: Outgoing) -> Result<(), Error> {
         {
             let mut extensions = self.extensions.lock().await;
             for e in &mut *extensions {
                 log::trace!("encoding with extension: {}", e.name());
-                e.encode(header, &mut data).map_err(Error::Extension)?
+                e.encode(header, data.as_mut()).map_err(Error::Extension)?
             }
         }
-        self.write(header, &mut data).await
+        self.write(header, data.as_mut()).await
     }
 
     /// Write final header and payload data to socket.
@@ -469,7 +504,7 @@ fn close_answer(data: &[u8]) -> Result<(Header, Option<u16>), Error> {
 }
 
 /// Turn a [`Receiver`] into a [`futures::Stream`].
-pub fn into_stream<T>(r: Receiver<T>) -> impl stream::Stream<Item = Result<(BytesMut, bool), Error>>
+pub fn into_stream<T>(r: Receiver<T>) -> impl stream::Stream<Item = Result<Incoming, Error>>
 where
     T: AsyncRead + AsyncWrite + Unpin
 {
@@ -482,7 +517,7 @@ where
     })
 }
 
-/// Connection error cases.
+/// Errors which may occur when sending or receiving messages.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// An I/O error was encountered.

--- a/src/data.rs
+++ b/src/data.rs
@@ -13,8 +13,8 @@
 //! Values of this type are produced when receiving data.
 //!
 //! - [`Outgoing`] data contains either normal application data such as text
-//! or binary data or application data to include in a PING control frame.
-//! Values of this type are used when sending data.
+//! or binary data or application data to include in a PING or PONG control
+//! frame. Values of this type are used when sending data.
 //!
 //! - [`Data`] contains either textual or binary data.
 
@@ -76,7 +76,9 @@ pub enum Outgoing {
     /// Text or binary data.
     Data(Data),
     /// Data to include in a PING control frame.
-    Ping(BytesMut)
+    Ping(BytesMut),
+    /// Data to include in a PONG control frame.
+    Pong(BytesMut)
 }
 
 impl Outgoing {
@@ -90,6 +92,11 @@ impl Outgoing {
         if let Outgoing::Ping(_) = self { true } else { false }
     }
 
+    /// Is this a PONG?
+    pub fn is_pong(&self) -> bool {
+        if let Outgoing::Pong(_) = self { true } else { false }
+    }
+
     /// The data length in bytes.
     pub fn len(&self) -> usize {
         self.as_ref().len()
@@ -100,7 +107,8 @@ impl AsRef<BytesMut> for Outgoing {
     fn as_ref(&self) -> &BytesMut {
         match self {
             Outgoing::Data(d) => d.as_ref(),
-            Outgoing::Ping(d) => d
+            Outgoing::Ping(d) => d,
+            Outgoing::Pong(d) => d
         }
     }
 }
@@ -109,7 +117,8 @@ impl AsMut<BytesMut> for Outgoing {
     fn as_mut(&mut self) -> &mut BytesMut {
         match self {
             Outgoing::Data(d) => d.as_mut(),
-            Outgoing::Ping(d) => d
+            Outgoing::Ping(d) => d,
+            Outgoing::Pong(d) => d
         }
     }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,0 +1,205 @@
+// Copyright (c) 2019 Parity Technologies (UK) Ltd.
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+//! The types of data to send or receive over a websocket connection.
+//!
+//! - [`Incoming`] data contains either normal application data such as text
+//! or binary data or application data included in a PONG control frame.
+//! Values of this type are produced when receiving data.
+//!
+//! - [`Outgoing`] data contains either normal application data such as text
+//! or binary data or application data to include in a PING control frame.
+//! Values of this type are used when sending data.
+//!
+//! - [`Data`] contains either textual or binary data.
+
+use bytes::BytesMut;
+
+/// Incoming data.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Incoming {
+    /// Text or binary data.
+    Data(Data),
+    /// Data sent with a PONG control frame.
+    Pong(BytesMut)
+}
+
+impl Incoming {
+    /// Is this text or binary data?
+    pub fn is_data(&self) -> bool {
+        if let Incoming::Data(_) = self { true } else { false }
+    }
+
+    /// Is this a PONG?
+    pub fn is_pong(&self) -> bool {
+        if let Incoming::Pong(_) = self { true } else { false }
+    }
+
+    /// The data length in bytes.
+    pub fn len(&self) -> usize {
+        self.as_ref().len()
+    }
+}
+
+impl AsRef<BytesMut> for Incoming {
+    fn as_ref(&self) -> &BytesMut {
+        match self {
+            Incoming::Data(d) => d.as_ref(),
+            Incoming::Pong(d) => d
+        }
+    }
+}
+
+impl AsMut<BytesMut> for Incoming {
+    fn as_mut(&mut self) -> &mut BytesMut {
+        match self {
+            Incoming::Data(d) => d.as_mut(),
+            Incoming::Pong(d) => d
+        }
+    }
+}
+
+impl From<Data> for Incoming {
+    fn from(d: Data) -> Self {
+        Incoming::Data(d)
+    }
+}
+
+/// Outgoing data.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Outgoing {
+    /// Text or binary data.
+    Data(Data),
+    /// Data to include in a PING control frame.
+    Ping(BytesMut)
+}
+
+impl Outgoing {
+    /// Is this text or binary data?
+    pub fn is_data(&self) -> bool {
+        if let Outgoing::Data(_) = self { true } else { false }
+    }
+
+    /// Is this a PING?
+    pub fn is_ping(&self) -> bool {
+        if let Outgoing::Ping(_) = self { true } else { false }
+    }
+
+    /// The data length in bytes.
+    pub fn len(&self) -> usize {
+        self.as_ref().len()
+    }
+}
+
+impl AsRef<BytesMut> for Outgoing {
+    fn as_ref(&self) -> &BytesMut {
+        match self {
+            Outgoing::Data(d) => d.as_ref(),
+            Outgoing::Ping(d) => d
+        }
+    }
+}
+
+impl AsMut<BytesMut> for Outgoing {
+    fn as_mut(&mut self) -> &mut BytesMut {
+        match self {
+            Outgoing::Data(d) => d.as_mut(),
+            Outgoing::Ping(d) => d
+        }
+    }
+}
+
+impl From<Data> for Outgoing {
+    fn from(d: Data) -> Self {
+        Outgoing::Data(d)
+    }
+}
+
+/// Payload application data.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Data {
+    /// Binary data.
+    Binary(BytesMut),
+    /// UTF-8 encoded data.
+    Text(BytesMut)
+}
+
+impl Data {
+    /// Is this binary data?
+    pub fn is_binary(&self) -> bool {
+        if let Data::Binary(_) = self { true } else { false }
+    }
+
+    /// Is this UTF-8 encoded textual data?
+    pub fn is_text(&self) -> bool {
+        if let Data::Text(_) = self { true } else { false }
+    }
+
+    /// The data length in bytes.
+    pub fn len(&self) -> usize {
+        self.as_ref().len()
+    }
+}
+
+impl AsRef<BytesMut> for Data {
+    fn as_ref(&self) -> &BytesMut {
+        match self {
+            Data::Binary(d) => d,
+            Data::Text(d) => d
+        }
+    }
+}
+
+impl AsMut<BytesMut> for Data {
+    fn as_mut(&mut self) -> &mut BytesMut {
+        match self {
+            Data::Binary(d) => d,
+            Data::Text(d) => d
+        }
+    }
+}
+
+impl Into<BytesMut> for Data {
+    fn into(self) -> BytesMut {
+        match self {
+            Data::Binary(d) => d,
+            Data::Text(d) => d
+        }
+    }
+}
+
+impl From<BytesMut> for Data {
+    fn from(b: BytesMut) -> Self {
+        Data::Binary(b)
+    }
+}
+
+impl From<&'_ str> for Data {
+    fn from(s: &str) -> Self {
+        Data::Text(BytesMut::from(s))
+    }
+}
+
+impl From<String> for Data {
+    fn from(s: String) -> Self {
+        Data::Text(BytesMut::from(s))
+    }
+}
+
+impl From<&'_ [u8]> for Data {
+    fn from(b: &[u8]) -> Self {
+        Data::Binary(BytesMut::from(b))
+    }
+}
+
+impl From<Vec<u8>> for Data {
+    fn from(b: Vec<u8>) -> Self {
+        Data::Binary(BytesMut::from(b))
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //!
 //! # Client example
 //!
-//! ```
+//! ```no_run
 //! # use async_std::net::TcpStream;
 //! # let _: Result<(), soketto::BoxedError> = async_std::task::block_on(async {
 //! use soketto::handshake::{Client, ServerResponse};
@@ -45,12 +45,12 @@
 //! };
 //!
 //! // Over the established websocket connection we can send
-//! sender.send_text("some text").await?;
-//! sender.send_text("some more text").await?;
+//! sender.send_data("some text").await?;
+//! sender.send_data("some more text").await?;
 //! sender.flush().await?;
 //!
 //! // ... and receive data.
-//! let (answer, is_text) = receiver.receive().await?;
+//! let data = receiver.receive_data().await?;
 //!
 //! # Ok(())
 //! # });
@@ -59,7 +59,7 @@
 //!
 //! # Server example
 //!
-//! ```
+//! ```no_run
 //! # use async_std::{net::TcpListener, prelude::*};
 //! # let _: Result<(), soketto::BoxedError> = async_std::task::block_on(async {
 //! use soketto::handshake::{Server, ClientRequest, server::Response};
@@ -83,12 +83,8 @@
 //!
 //!     // And we can finally transition to a websocket connection.
 //!     let (mut sender, mut receiver) = server.into_builder().finish();
-//!     let (message, is_text) = receiver.receive().await?;
-//!     if is_text {
-//!         sender.send_text(message).await?
-//!     } else {
-//!         sender.send_binary(message).await?
-//!     }
+//!     let message = receiver.receive_data().await?;
+//!     sender.send_data(message).await?;
 //!     sender.close().await?;
 //! }
 //!
@@ -104,12 +100,17 @@
 //! [handshake]: https://tools.ietf.org/html/rfc6455#section-4
 
 pub mod base;
+pub mod data;
 pub mod extension;
 pub mod handshake;
 pub mod connection;
 
 use bytes::{BufMut, BytesMut};
 use futures::io::{AsyncRead, AsyncReadExt};
+
+pub use data::Data;
+pub use connection::{Mode, Receiver, Sender};
+
 pub type BoxedError = Box<dyn std::error::Error + Send + Sync>;
 
 /// A parsing result.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,8 +147,9 @@ where
     R: AsyncRead + Unpin
 {
     unsafe {
+        debug_assert!(b.has_remaining_mut());
         let n = r.read(b.bytes_mut()).await?;
-        if n == 0 && b.has_remaining_mut() {
+        if n == 0 {
             return Err(std::io::ErrorKind::UnexpectedEof.into())
         }
         b.advance_mut(n);


### PR DESCRIPTION
To allow use-cases such as heartbeats or availability checks, sending PING and PONG control frames and receiving PONG control frames is now supported. While we always automatically answered incoming PINGs (which we still do), we ignored incoming PONGs.

To support this, we no longer just return `(BytesMut, bool)` from `receive` but instead an enum `Incoming` which is either another enum `Data`, composed of text or binary data, or a `Pong`. Applications which are not interested in processing PONGs can use `receive_data` which skips over non-data messages.

On the sending side we now use an `Outgoing` enum which is either `Data`, again composed of text or binary data, or a `Ping` or `Pong`. Applications which do not want to send PINGs and PONGs can use `send_data` which accepts only the `Data` enum.

For all those types several `From` and `Into` conversions are defined which should make their use convenient.

These changes allow applications to send PINGs and await matching PONGs, taking appropriate action if their expectations are not met as well as sending unsolicited PONGs as a form of heartbeat message.