### PR TITLE
Rework data model and update to bytes-0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ deflate = ["flate2"]
 [dependencies]
 base64 = "0.10.1"
 bytes = "0.5"
-either = "1.5"
 flate2 = { version = "1.0.8", features = ["zlib"], default-features = false, optional = true }
 futures = { version = "0.3.1", features = ["unstable", "bilock"] }
 http = "0.1.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ deflate_with_uninitialised_memory = []
 [dependencies]
 base64 = "0.10.1"
 bytes = "0.4.12"
+either = "1.5"
 flate2 = { version = "1.0.8", features = ["zlib"], default-features = false, optional = true }
 futures = { version = "0.3.1", features = ["unstable", "bilock"] }
 http = "0.1.17"
@@ -36,5 +37,5 @@ thiserror = "1.0"
 
 [dev-dependencies]
 assert_matches = "1.3"
-async-std = "1.1"
+async-std = "1"
 quickcheck = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,15 +14,10 @@ all-features = true
 
 [features]
 deflate = ["flate2"]
-# This feature enables the use of uninitialised memory for the deflate
-# extension. When compressing or decompressing, an uninitialised byte
-# slice will be used for writing the resulting bytes, assuming that
-# flate2 really only writes to and does not read from this memory.
-deflate_with_uninitialised_memory = []
 
 [dependencies]
 base64 = "0.10.1"
-bytes = "0.4.12"
+bytes = "0.5"
 either = "1.5"
 flate2 = { version = "1.0.8", features = ["zlib"], default-features = false, optional = true }
 futures = { version = "0.3.1", features = ["unstable", "bilock"] }

--- a/examples/autobahn_client.rs
+++ b/examples/autobahn_client.rs
@@ -56,7 +56,11 @@ async fn run_case(n: usize) -> Result<(), BoxedError> {
     loop {
         match receiver.receive_data().await {
             Ok(data) => {
-                sender.send_data(data).await?;
+                if data.is_binary() {
+                    sender.send_binary(&data).await?
+                } else {
+                    sender.send_text(std::str::from_utf8(data.as_ref()).unwrap()).await?
+                }
                 sender.flush().await?
             }
             Err(connection::Error::Closed) => return Ok(()),

--- a/examples/autobahn_client.rs
+++ b/examples/autobahn_client.rs
@@ -59,7 +59,7 @@ async fn run_case(n: usize) -> Result<(), BoxedError> {
                 if data.is_binary() {
                     sender.send_binary(&data).await?
                 } else {
-                    sender.send_text(std::str::from_utf8(data.as_ref()).unwrap()).await?
+                    sender.send_text(std::str::from_utf8(data.as_ref())?).await?
                 }
                 sender.flush().await?
             }

--- a/examples/autobahn_client.rs
+++ b/examples/autobahn_client.rs
@@ -55,9 +55,9 @@ async fn run_case(n: usize) -> Result<(), BoxedError> {
     let (mut sender, mut receiver) = client.into_builder().finish();
     loop {
         match receiver.receive_data().await {
-            Ok(data) => {
+            Ok(mut data) => {
                 if data.is_binary() {
-                    sender.send_binary(&data).await?
+                    sender.send_binary_mut(&mut data).await?
                 } else {
                     sender.send_text(std::str::from_utf8(data.as_ref())?).await?
                 }

--- a/examples/autobahn_server.rs
+++ b/examples/autobahn_server.rs
@@ -32,9 +32,9 @@ fn main() -> Result<(), BoxedError> {
             let (mut sender, mut receiver) = server.into_builder().finish();
             loop {
                 match receiver.receive_data().await {
-                    Ok(data) => {
+                    Ok(mut data) => {
                         if data.is_binary() {
-                            sender.send_binary(&data).await?;
+                            sender.send_binary_mut(&mut data).await?;
                         } else {
                             sender.send_text(std::str::from_utf8(data.as_ref())?).await?;
                         }

--- a/examples/autobahn_server.rs
+++ b/examples/autobahn_server.rs
@@ -35,8 +35,10 @@ fn main() -> Result<(), BoxedError> {
                     Ok(mut data) => {
                         if data.is_binary() {
                             sender.send_binary_mut(&mut data).await?;
+                        } else if let Ok(txt) = std::str::from_utf8(data.as_ref()) {
+                            sender.send_text(txt).await?
                         } else {
-                            sender.send_text(std::str::from_utf8(data.as_ref())?).await?;
+                            break
                         }
                         sender.flush().await?
                     }

--- a/examples/autobahn_server.rs
+++ b/examples/autobahn_server.rs
@@ -33,7 +33,11 @@ fn main() -> Result<(), BoxedError> {
             loop {
                 match receiver.receive_data().await {
                     Ok(data) => {
-                        sender.send_data(data).await?;
+                        if data.is_binary() {
+                            sender.send_binary(&data).await?;
+                        } else {
+                            sender.send_text(std::str::from_utf8(data.as_ref()).unwrap()).await?;
+                        }
                         sender.flush().await?
                     }
                     Err(connection::Error::Closed) => break,

--- a/examples/autobahn_server.rs
+++ b/examples/autobahn_server.rs
@@ -36,7 +36,7 @@ fn main() -> Result<(), BoxedError> {
                         if data.is_binary() {
                             sender.send_binary(&data).await?;
                         } else {
-                            sender.send_text(std::str::from_utf8(data.as_ref()).unwrap()).await?;
+                            sender.send_text(std::str::from_utf8(data.as_ref())?).await?;
                         }
                         sender.flush().await?
                     }

--- a/src/base.rs
+++ b/src/base.rs
@@ -118,7 +118,7 @@ impl fmt::Display for OpCode {
 
 /// Error returned by `OpCode::try_from` if an unknown opcode
 /// number is encountered.
-#[derive(Debug, thiserror::Error)]
+#[derive(Clone, Debug, thiserror::Error)]
 #[error("unknown opcode")]
 pub struct UnknownOpCode(());
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -413,22 +413,14 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Sender<T> {
 
     /// Ping the remote end.
     pub async fn send_ping(&mut self, data: ByteSlice125<'_>) -> Result<(), Error> {
-        let mut buf = [0; 125];
-        let src = data.as_ref();
-        let dst = &mut buf[.. src.len()];
-        dst.copy_from_slice(src);
         let mut header = Header::new(OpCode::Ping);
-        self.write(&mut header, &mut Storage::Shared(dst)).await
+        self.write(&mut header, &mut Storage::Shared(data.as_ref())).await
     }
 
     /// Send an unsolicited Pong to the remote.
     pub async fn send_pong(&mut self, data: ByteSlice125<'_>) -> Result<(), Error> {
-        let mut buf = [0; 125];
-        let src = data.as_ref();
-        let dst = &mut buf[.. src.len()];
-        dst.copy_from_slice(src);
         let mut header = Header::new(OpCode::Pong);
-        self.write(&mut header, &mut Storage::Shared(dst)).await
+        self.write(&mut header, &mut Storage::Shared(data.as_ref())).await
     }
 
     /// Flush the socket buffer.

--- a/src/data.rs
+++ b/src/data.rs
@@ -9,7 +9,7 @@
 use bytes::BytesMut;
 use std::convert::TryFrom;
 
-/// Incoming data.
+/// Data received from the remote end.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Incoming {
     /// Text or binary data.
@@ -62,7 +62,7 @@ impl Into<Data> for Incoming {
     }
 }
 
-/// Payload application data.
+/// Application data.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Data(DataRepr);
 
@@ -82,6 +82,7 @@ impl Data {
 
     /// Create a new textual `Data` value.
     pub(crate) fn text(b: BytesMut) -> Self {
+        debug_assert!(std::str::from_utf8(&b).is_ok());
         Data(DataRepr::Text(b))
     }
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -29,6 +29,24 @@ impl Incoming {
         if let Incoming::Pong(_) = self { true } else { false }
     }
 
+    /// Is this text data?
+    pub fn is_text(&self) -> bool {
+        if let Incoming::Data(d) = self {
+            d.is_text()
+        } else {
+            false
+        }
+    }
+
+    /// Is this binary data?
+    pub fn is_binary(&self) -> bool {
+        if let Incoming::Data(d) = self {
+            d.is_binary()
+        } else {
+            false
+        }
+    }
+
     /// Data length in bytes.
     pub fn len(&self) -> usize {
         self.as_ref().len()

--- a/src/data.rs
+++ b/src/data.rs
@@ -126,12 +126,17 @@ pub struct ByteSlice125<'a>(&'a [u8]);
 
 static_assertions::const_assert_eq!(125, crate::base::MAX_CTRL_BODY_SIZE);
 
+/// Error, if converting to `[ByteSlice125`] fails.
+#[derive(Clone, Debug, thiserror::Error)]
+#[error("Slice larger than 125 bytes")]
+pub struct SliceTooLarge(());
+
 impl<'a> TryFrom<&'a [u8]> for ByteSlice125<'a> {
-    type Error = ();
+    type Error = SliceTooLarge;
 
     fn try_from(value: &'a [u8]) -> Result<Self, Self::Error> {
         if value.len() > 125 {
-            Err(())
+            Err(SliceTooLarge(()))
         } else {
             Ok(ByteSlice125(value))
         }

--- a/src/data.rs
+++ b/src/data.rs
@@ -6,21 +6,7 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
-//! The types of data to send or receive over a websocket connection.
-//!
-//! - [`Incoming`] data contains either normal application data such as text
-//! or binary data or application data included in a PONG control frame.
-//! Values of this type are produced when receiving data.
-//!
-//! - [`Outgoing`] data contains either normal application data such as text
-//! or binary data or application data to include in a PING or PONG control
-//! frame. Values of this type are used when sending data.
-//!
-//! - [`Data`] contains either textual or binary data.
-
 use bytes::BytesMut;
-use crate::base;
-use static_assertions::const_assert_eq;
 use std::convert::TryFrom;
 
 /// Incoming data.
@@ -29,7 +15,7 @@ pub enum Incoming {
     /// Text or binary data.
     Data(Data),
     /// Data sent with a PONG control frame.
-    Pong(BytesMut)
+    Pong(Data)
 }
 
 impl Incoming {
@@ -43,101 +29,45 @@ impl Incoming {
         if let Incoming::Pong(_) = self { true } else { false }
     }
 
-    /// The data length in bytes.
+    /// Data length in bytes.
     pub fn len(&self) -> usize {
         self.as_ref().len()
     }
 }
 
-impl AsRef<BytesMut> for Incoming {
-    fn as_ref(&self) -> &BytesMut {
+impl AsRef<[u8]> for Incoming {
+    fn as_ref(&self) -> &[u8] {
         match self {
             Incoming::Data(d) => d.as_ref(),
-            Incoming::Pong(d) => d
+            Incoming::Pong(d) => d.as_ref()
         }
     }
 }
 
-impl AsMut<BytesMut> for Incoming {
-    fn as_mut(&mut self) -> &mut BytesMut {
+impl AsMut<[u8]> for Incoming {
+    fn as_mut(&mut self) -> &mut [u8] {
         match self {
             Incoming::Data(d) => d.as_mut(),
+            Incoming::Pong(d) => d.as_mut()
+        }
+    }
+}
+
+impl Into<Data> for Incoming {
+    fn into(self: Incoming) -> Data {
+        match self {
+            Incoming::Data(d) => d,
             Incoming::Pong(d) => d
         }
-    }
-}
-
-impl Into<BytesMut> for Incoming {
-    fn into(self: Incoming) -> BytesMut {
-        match self {
-            Incoming::Data(d) => d.into(),
-            Incoming::Pong(p) => p
-        }
-    }
-}
-
-/// Outgoing data.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum Outgoing {
-    /// Text or binary data.
-    Data(Data),
-    /// Data to include in a PING control frame.
-    Ping(BytesMut125),
-    /// Data to include in a PONG control frame.
-    Pong(BytesMut125)
-}
-
-impl Outgoing {
-    /// Is this text or binary data?
-    pub fn is_data(&self) -> bool {
-        if let Outgoing::Data(_) = self { true } else { false }
-    }
-
-    /// Is this a PING?
-    pub fn is_ping(&self) -> bool {
-        if let Outgoing::Ping(_) = self { true } else { false }
-    }
-
-    /// Is this a PONG?
-    pub fn is_pong(&self) -> bool {
-        if let Outgoing::Pong(_) = self { true } else { false }
-    }
-
-    /// The data length in bytes.
-    pub fn len(&self) -> usize {
-        self.as_ref().len()
-    }
-}
-
-impl AsRef<BytesMut> for Outgoing {
-    fn as_ref(&self) -> &BytesMut {
-        match self {
-            Outgoing::Data(d) => d.as_ref(),
-            Outgoing::Ping(d) => d.as_ref(),
-            Outgoing::Pong(d) => d.as_ref()
-        }
-    }
-}
-
-impl Into<BytesMut> for Outgoing {
-    fn into(self: Outgoing) -> BytesMut {
-        match self {
-            Outgoing::Data(d) => d.into(),
-            Outgoing::Ping(p) => p.into(),
-            Outgoing::Pong(p) => p.into()
-        }
-    }
-}
-
-impl From<Data> for Outgoing {
-    fn from(d: Data) -> Self {
-        Outgoing::Data(d)
     }
 }
 
 /// Payload application data.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum Data {
+pub struct Data(DataRepr);
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+enum DataRepr {
     /// Binary data.
     Binary(BytesMut),
     /// UTF-8 encoded data.
@@ -145,106 +75,71 @@ pub enum Data {
 }
 
 impl Data {
+    /// Create a new binary `Data` value.
+    pub(crate) fn binary(b: BytesMut) -> Self {
+        Data(DataRepr::Binary(b))
+    }
+
+    /// Create a new textual `Data` value.
+    pub(crate) fn text(b: BytesMut) -> Self {
+        Data(DataRepr::Text(b))
+    }
+
     /// Is this binary data?
     pub fn is_binary(&self) -> bool {
-        if let Data::Binary(_) = self { true } else { false }
+        if let DataRepr::Binary(_) = self.0 { true } else { false }
     }
 
     /// Is this UTF-8 encoded textual data?
     pub fn is_text(&self) -> bool {
-        if let Data::Text(_) = self { true } else { false }
+        if let DataRepr::Text(_) = self.0 { true } else { false }
     }
 
-    /// The data length in bytes.
+    /// Data length in bytes.
     pub fn len(&self) -> usize {
         self.as_ref().len()
     }
 }
 
-impl AsRef<BytesMut> for Data {
-    fn as_ref(&self) -> &BytesMut {
-        match self {
-            Data::Binary(d) => d,
-            Data::Text(d) => d
+impl AsRef<[u8]> for Data {
+    fn as_ref(&self) -> &[u8] {
+        match &self.0 {
+            DataRepr::Binary(d) => d,
+            DataRepr::Text(d) => d
         }
     }
 }
 
-impl AsMut<BytesMut> for Data {
-    fn as_mut(&mut self) -> &mut BytesMut {
-        match self {
-            Data::Binary(d) => d,
-            Data::Text(d) => d
+impl AsMut<[u8]> for Data {
+    fn as_mut(&mut self) -> &mut [u8] {
+        match &mut self.0 {
+            DataRepr::Binary(d) => d,
+            DataRepr::Text(d) => d
         }
     }
 }
 
-impl Into<BytesMut> for Data {
-    fn into(self) -> BytesMut {
-        match self {
-            Data::Binary(d) => d,
-            Data::Text(d) => d
-        }
-    }
-}
+/// Wrapper which restricts the length of its byte slice to 125 bytes.
+#[derive(Debug)]
+pub struct ByteSlice125<'a>(&'a [u8]);
 
-impl From<BytesMut> for Data {
-    fn from(b: BytesMut) -> Self {
-        Data::Binary(b)
-    }
-}
+static_assertions::const_assert_eq!(125, crate::base::MAX_CTRL_BODY_SIZE);
 
-impl From<&'_ str> for Data {
-    fn from(s: &str) -> Self {
-        Data::Text(BytesMut::from(s))
-    }
-}
-
-impl From<String> for Data {
-    fn from(s: String) -> Self {
-        Data::Text(BytesMut::from(s))
-    }
-}
-
-impl From<&'_ [u8]> for Data {
-    fn from(b: &[u8]) -> Self {
-        Data::Binary(BytesMut::from(b))
-    }
-}
-
-impl From<Vec<u8>> for Data {
-    fn from(b: Vec<u8>) -> Self {
-        Data::Binary(BytesMut::from(b))
-    }
-}
-
-/// [`BytesMut`] wrapper which restricts its size to 125 bytes.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct BytesMut125(BytesMut);
-
-const_assert_eq!(125, base::MAX_CTRL_BODY_SIZE);
-
-impl TryFrom<BytesMut> for BytesMut125 {
+impl<'a> TryFrom<&'a [u8]> for ByteSlice125<'a> {
     type Error = ();
 
-    fn try_from(value: BytesMut) -> Result<Self, Self::Error> {
+    fn try_from(value: &'a [u8]) -> Result<Self, Self::Error> {
         if value.len() > 125 {
             Err(())
         } else {
-            Ok(BytesMut125(value))
+            Ok(ByteSlice125(value))
         }
     }
 }
 
-impl Into<BytesMut> for BytesMut125 {
-    fn into(self) -> BytesMut {
+impl AsRef<[u8]> for ByteSlice125<'_> {
+    fn as_ref(&self) -> &[u8] {
         self.0
-    }
-}
-
-impl AsRef<BytesMut> for BytesMut125 {
-    fn as_ref(&self) -> &BytesMut {
-        &self.0
     }
 }
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -46,11 +46,6 @@ impl Incoming {
             false
         }
     }
-
-    /// Data length in bytes.
-    pub fn len(&self) -> usize {
-        self.as_ref().len()
-    }
 }
 
 impl AsRef<[u8]> for Incoming {
@@ -112,11 +107,6 @@ impl Data {
     /// Is this UTF-8 encoded textual data?
     pub fn is_text(&self) -> bool {
         if let DataRepr::Text(_) = self.0 { true } else { false }
-    }
-
-    /// Data length in bytes.
-    pub fn len(&self) -> usize {
-        self.as_ref().len()
     }
 }
 

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -16,6 +16,7 @@ pub mod deflate;
 
 use bytes::BytesMut;
 use crate::{BoxedError, base::Header};
+use either::Either;
 use std::{borrow::Cow, fmt};
 
 /// A websocket extension as per RFC 6455, section 9.
@@ -61,7 +62,7 @@ pub trait Extension: std::fmt::Debug {
     fn configure(&mut self, params: &[Param]) -> Result<(), BoxedError>;
 
     /// Encode a frame, given as frame header and payload data.
-    fn encode(&mut self, header: &mut Header, data: &[u8]) -> Result<Option<BytesMut>, BoxedError>;
+    fn encode(&mut self, header: &mut Header, data: &mut Either<&[u8], BytesMut>) -> Result<(), BoxedError>;
 
     /// Decode a frame.
     ///
@@ -92,7 +93,7 @@ impl<E: Extension + ?Sized> Extension for Box<E> {
         (**self).configure(params)
     }
 
-    fn encode(&mut self, header: &mut Header, data: &[u8]) -> Result<Option<BytesMut>, BoxedError> {
+    fn encode(&mut self, header: &mut Header, data: &mut Either<&[u8], BytesMut>) -> Result<(), BoxedError> {
         (**self).encode(header, data)
     }
 

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -61,7 +61,7 @@ pub trait Extension: std::fmt::Debug {
     fn configure(&mut self, params: &[Param]) -> Result<(), BoxedError>;
 
     /// Encode a frame, given as frame header and payload data.
-    fn encode(&mut self, header: &mut Header, data: &mut BytesMut) -> Result<(), BoxedError>;
+    fn encode(&mut self, header: &mut Header, data: &[u8]) -> Result<Option<BytesMut>, BoxedError>;
 
     /// Decode a frame.
     ///
@@ -92,7 +92,7 @@ impl<E: Extension + ?Sized> Extension for Box<E> {
         (**self).configure(params)
     }
 
-    fn encode(&mut self, header: &mut Header, data: &mut BytesMut) -> Result<(), BoxedError> {
+    fn encode(&mut self, header: &mut Header, data: &[u8]) -> Result<Option<BytesMut>, BoxedError> {
         (**self).encode(header, data)
     }
 

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -15,8 +15,7 @@
 pub mod deflate;
 
 use bytes::BytesMut;
-use crate::{BoxedError, base::Header};
-use either::Either;
+use crate::{BoxedError, Storage, base::Header};
 use std::{borrow::Cow, fmt};
 
 /// A websocket extension as per RFC 6455, section 9.
@@ -62,7 +61,7 @@ pub trait Extension: std::fmt::Debug {
     fn configure(&mut self, params: &[Param]) -> Result<(), BoxedError>;
 
     /// Encode a frame, given as frame header and payload data.
-    fn encode(&mut self, header: &mut Header, data: &mut Either<&[u8], BytesMut>) -> Result<(), BoxedError>;
+    fn encode(&mut self, header: &mut Header, data: &mut Storage) -> Result<(), BoxedError>;
 
     /// Decode a frame.
     ///
@@ -93,7 +92,7 @@ impl<E: Extension + ?Sized> Extension for Box<E> {
         (**self).configure(params)
     }
 
-    fn encode(&mut self, header: &mut Header, data: &mut Either<&[u8], BytesMut>) -> Result<(), BoxedError> {
+    fn encode(&mut self, header: &mut Header, data: &mut Storage) -> Result<(), BoxedError> {
         (**self).encode(header, data)
     }
 

--- a/src/extension/deflate.rs
+++ b/src/extension/deflate.rs
@@ -10,7 +10,7 @@
 //!
 //! [rfc7692]: https://tools.ietf.org/html/rfc7692
 
-use bytes::BytesMut;
+use bytes::{buf::BufMutExt, BytesMut};
 use crate::{
     as_u64,
     BoxedError,
@@ -19,9 +19,9 @@ use crate::{
     connection::Mode,
     extension::{Extension, Param}
 };
-use flate2::{Compress, Compression, Decompress, FlushCompress, FlushDecompress};
+use flate2::{Compress, Compression, FlushCompress, write::DeflateDecoder};
 use smallvec::SmallVec;
-use std::convert::TryInto;
+use std::{convert::TryInto, io::{self, Write}};
 
 const SERVER_NO_CONTEXT_TAKEOVER: &str = "server_no_context_takeover";
 const SERVER_MAX_WINDOW_BITS: &str = "server_max_window_bits";
@@ -227,6 +227,10 @@ impl Extension for Deflate {
     }
 
     fn decode(&mut self, header: &mut Header, data: &mut BytesMut) -> Result<(), BoxedError> {
+        if data.is_empty() {
+            return Ok(())
+        }
+
         match header.opcode() {
             OpCode::Binary | OpCode::Text if header.is_rsv1() => {
                 if !header.is_fin() {
@@ -246,34 +250,25 @@ impl Extension for Deflate {
             }
         }
 
-        if data.is_empty() {
-            return Ok(())
-        }
-
-        data.extend_from_slice(&[0, 0, 0xFF, 0xFF]); // cf. RFC 7692, section 7.2.2
+        // Restore LEN and NLEN:
+        data.extend_from_slice(&[0, 0, 0xFF, 0xFF]); // cf. RFC 7692, 7.2.2
 
         self.buffer.clear();
+        let mut decoder = DeflateDecoder::new(self.buffer.take().into_bytes().writer());
+        decoder.write_all(&data)?;
+        *data = decoder.finish()?.into_inner();
 
-        let mut d = Decompress::new_with_window_bits(false, self.their_max_window_bits);
-        while d.total_in() < as_u64(data.len()) {
-            let off: usize = d.total_in().try_into()?;
-            self.buffer.reserve(data.len() - off);
-            let n = d.total_out();
-            d.decompress(&data[off ..], self.buffer.bytes_mut(), FlushDecompress::Sync)?;
-            self.buffer.advance_mut((d.total_out() - n).try_into()?);
-        }
-
-        let uncompressed = self.buffer.take().into_bytes();
         header.set_rsv1(false);
-        header.set_payload_len(uncompressed.len());
-        //*data = uncompressed;
-        data.clear();
-        data.extend_from_slice(&uncompressed);
+        header.set_payload_len(data.len());
 
         Ok(())
     }
 
     fn encode(&mut self, header: &mut Header, data: &mut Storage) -> Result<(), BoxedError> {
+        if data.as_ref().is_empty() {
+            return Ok(())
+        }
+
         if let OpCode::Binary | OpCode::Text = header.opcode() {
             log::trace!("deflate: encoding {}", header)
         } else {
@@ -281,38 +276,35 @@ impl Extension for Deflate {
             return Ok(())
         }
 
-        {
-            let data = data.as_ref();
+        self.buffer.clear();
 
-            if data.is_empty() {
-                return Ok(())
-            }
+        let mut encoder =
+            Compress::new_with_window_bits(Compression::fast(), false, self.our_max_window_bits);
 
-            self.buffer.clear();
-
-            let mut c = {
-                let mwb = self.our_max_window_bits;
-                Compress::new_with_window_bits(Compression::fast(), false, mwb)
-            };
-
-            while c.total_in() < as_u64(data.len()) {
-                let off: usize = c.total_in().try_into()?;
-                self.buffer.reserve(data.len() - off);
-                let n = c.total_out();
-                c.compress(&data[off ..], self.buffer.bytes_mut(), FlushCompress::Sync)?;
-                self.buffer.advance_mut((c.total_out() - n).try_into()?)
-            }
-
-            if self.buffer.remaining_mut() < 5 {
-                self.buffer.reserve(5); // Make room for the trailing end bytes
-                let n = c.total_out();
-                c.compress(&[], self.buffer.bytes_mut(), FlushCompress::Sync)?;
-                self.buffer.advance_mut((c.total_out() - n).try_into()?)
-            }
+        // Compress all input bytes.
+        while encoder.total_in() < as_u64(data.as_ref().len()) {
+            let off: usize = encoder.total_in().try_into()?;
+            self.buffer.reserve(data.as_ref().len() - off);
+            let n = encoder.total_out();
+            encoder.compress(&data.as_ref()[off ..], self.buffer.bytes_mut(), FlushCompress::Sync)?;
+            self.buffer.advance_mut((encoder.total_out() - n).try_into()?)
         }
 
-        let n = self.buffer.len() - 4;
-        self.buffer.truncate(n); // Remove [0, 0, 0xFF, 0xFF]; cf. RFC 7692, section 7.2.1
+        // We need to append an empty deflate block if not there yet (RFC 7692, 7.2.1).
+        if !self.buffer.as_ref().ends_with(&[0, 0, 0xFF, 0xFF]) {
+            self.buffer.reserve(5); // Make sure there is room for the trailing end bytes.
+            let n = encoder.total_out();
+            encoder.compress(&[], self.buffer.bytes_mut(), FlushCompress::Sync)?;
+            self.buffer.advance_mut((encoder.total_out() - n).try_into()?)
+        }
+
+        // If we still have not seen the empty deflate block appended, something is wrong.
+        if !self.buffer.as_ref().ends_with(&[0, 0, 0xFF, 0xFF]) {
+            log::error!("missing 00 00 FF FF");
+            return Err(io::Error::new(io::ErrorKind::Other, "missing 00 00 FF FF").into())
+        }
+
+        self.buffer.truncate(self.buffer.len() - 4); // Remove 00 00 FF FF; cf. RFC 7692, 7.2.1
         let compressed = self.buffer.take().into_bytes();
         header.set_rsv1(true);
         header.set_payload_len(compressed.len());

--- a/src/extension/deflate.rs
+++ b/src/extension/deflate.rs
@@ -261,7 +261,7 @@ impl Extension for Deflate {
             let n = d.total_out();
             unsafe {
                 let b = self.buffer.bytes_mut();
-                let b = &mut *(b as *mut [MaybeUninit<u8>] as *mut [u8]);
+                let b = std::mem::transmute::<&mut [MaybeUninit<u8>], &mut [u8]>(b);
                 d.decompress(&data[off ..], b, FlushDecompress::Sync)?;
                 self.buffer.advance_mut((d.total_out() - n).try_into()?);
             }
@@ -302,7 +302,7 @@ impl Extension for Deflate {
                 let n = c.total_out();
                 unsafe {
                     let b = self.buffer.bytes_mut();
-                    let b = &mut *(b as *mut [MaybeUninit<u8>] as *mut [u8]);
+                    let b = std::mem::transmute::<&mut [MaybeUninit<u8>], &mut [u8]>(b);
                     c.compress(&data[off ..], b, FlushCompress::Sync)?;
                     self.buffer.advance_mut((c.total_out() - n).try_into()?)
                 }
@@ -313,7 +313,7 @@ impl Extension for Deflate {
                 let n = c.total_out();
                 unsafe {
                     let b = self.buffer.bytes_mut();
-                    let b = &mut *(b as *mut [MaybeUninit<u8>] as *mut [u8]);
+                    let b = std::mem::transmute::<&mut [MaybeUninit<u8>], &mut [u8]>(b);
                     c.compress(&[], b, FlushCompress::Sync)?;
                     self.buffer.advance_mut((c.total_out() - n).try_into()?)
                 }

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -13,7 +13,6 @@
 pub mod client;
 pub mod server;
 
-use bytes::BytesMut;
 use crate::extension::{Param, Extension};
 use smallvec::SmallVec;
 use std::{io, str};
@@ -100,7 +99,7 @@ fn configure_extensions(extensions: &mut [Box<dyn Extension + Send>], line: &str
 }
 
 // Write all extensions to the given buffer.
-fn append_extensions<'a, I>(extensions: I, bytes: &mut BytesMut)
+fn append_extensions<'a, I>(extensions: I, bytes: &mut crate::Buffer)
 where
     I: IntoIterator<Item = &'a Box<dyn Extension + Send>>
 {

--- a/src/handshake/client.rs
+++ b/src/handshake/client.rs
@@ -10,7 +10,7 @@
 //!
 //! [handshake]: https://tools.ietf.org/html/rfc6455#section-4
 
-use bytes::{BufMut, BytesMut};
+use bytes::BytesMut;
 use crate::{Parsing, extension::Extension};
 use crate::connection::{self, Mode};
 use futures::prelude::*;
@@ -107,7 +107,7 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Client<'a, T> {
         self.buffer.clear();
 
         loop {
-            if !self.buffer.has_remaining_mut() {
+            if self.buffer.capacity() - self.buffer.len() < BLOCK_SIZE {
                 crate::reserve(&mut self.buffer, BLOCK_SIZE)
             }
             crate::read(&mut self.socket, &mut self.buffer).await?;

--- a/src/handshake/client.rs
+++ b/src/handshake/client.rs
@@ -121,7 +121,8 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Client<'a, T> {
     /// Turn this handshake into a [`connection::Builder`].
     pub fn into_builder(mut self) -> connection::Builder<T> {
         let mut builder = connection::Builder::new(self.socket, Mode::Client);
-        builder.set_buffer(self.buffer).add_extensions(self.extensions.drain(..));
+        builder.set_buffer(self.buffer);
+        builder.add_extensions(self.extensions.drain(..));
         builder
     }
 

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -10,7 +10,7 @@
 //!
 //! [handshake]: https://tools.ietf.org/html/rfc6455#section-4
 
-use bytes::{BufMut, BytesMut};
+use bytes::BytesMut;
 use crate::{Parsing, extension::Extension};
 use crate::connection::{self, Mode};
 use futures::prelude::*;
@@ -82,7 +82,7 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Server<'a, T> {
     pub async fn receive_request(&mut self) -> Result<ClientRequest<'a>, Error> {
         self.buffer.clear();
         loop {
-            if !self.buffer.has_remaining_mut() {
+            if self.buffer.capacity() - self.buffer.len() < BLOCK_SIZE {
                 crate::reserve(&mut self.buffer, BLOCK_SIZE)
             }
             crate::read(&mut self.socket, &mut self.buffer).await?;

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -106,7 +106,8 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Server<'a, T> {
     /// Turn this handshake into a [`connection::Builder`].
     pub fn into_builder(mut self) -> connection::Builder<T> {
         let mut builder = connection::Builder::new(self.socket, Mode::Server);
-        builder.set_buffer(self.buffer).add_extensions(self.extensions.drain(..));
+        builder.set_buffer(self.buffer);
+        builder.add_extensions(self.extensions.drain(..));
         builder
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,17 +82,14 @@
 //!     server.send_response(&accept).await?;
 //!
 //!     // And we can finally transition to a websocket connection.
-//!     let mut builder = server.into_builder();
-//!     builder.validate_utf8(false);
-//!
-//!     let (mut sender, mut receiver) = builder.finish();
+//!     let (mut sender, mut receiver) = server.into_builder().finish();
 //!
 //!     let data = receiver.receive_data().await?;
 //!
-//!     if data.is_binary() {
-//!         sender.send_binary(data.as_ref()).await?
-//!     } else {
+//!     if data.is_text() {
 //!         sender.send_text(std::str::from_utf8(data.as_ref())?).await?
+//!     } else {
+//!         sender.send_binary(data.as_ref()).await?
 //!     }
 //!
 //!     sender.close().await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,27 @@ pub enum Parsing<T, N = ()> {
     NeedMore(N)
 }
 
+/// A buffer type used for implementing `Extension`s.
+#[derive(Debug)]
+pub enum Storage<'a> {
+    /// A read-only shared byte slice.
+    Shared(&'a [u8]),
+    /// A mutable byte slice.
+    Unique(&'a mut [u8]),
+    /// An owned byte buffer.
+    Owned(BytesMut)
+}
+
+impl AsRef<[u8]> for Storage<'_> {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            Storage::Shared(d) => d,
+            Storage::Unique(d) => d,
+            Storage::Owned(b) => b.as_ref()
+        }
+    }
+}
+
 /// Helper function to allow casts from `usize` to `u64` only on platforms
 /// where the sizes are guaranteed to fit.
 #[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
@@ -167,6 +188,8 @@ where
     Ok(())
 }
 
+/// Return all bytes from the given `BytesMut`, leaving it empty.
 pub(crate) fn take(bytes: &mut BytesMut) -> BytesMut {
     bytes.split_to(bytes.len())
 }
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,7 @@ where
 {
     unsafe {
         let b = bytes.bytes_mut();
-        let b = &mut *(b as *mut [MaybeUninit<u8>] as *mut [u8]);
+        let b = std::mem::transmute::<&mut [MaybeUninit<u8>], &mut [u8]>(b);
         debug_assert!(!b.is_empty());
         let n = reader.read(b).await?;
         if n == 0 {


### PR DESCRIPTION
This PR attempts to make `BytesMut` more of an implementation detail and less part of the public API. To do so the following changes have been made:

1. `data::Data` hides its internal `BytesMut` and is usable only via its `AsRef`/`AsMut` impls.
2. `data::Outgoing` has been removed. Instead of a single `Sender::send` method we support multiple, e.g. `send_text`, `send_ping` etc., each being generic over its parameter type (e.g. `impl AsRef<[u8]>`).

In addition, to allow buffer-reuse when running a sequence of extensions, a `Storage` type has been added which allows upgrading from a shared read-only byte slice to an owned buffer. This 
owned buffer is the only place where `BytesMut` is still part of the public API, albeit only relevant for extension writers.

The `Storage` type also helps with the conflict between the desire to directly send `&str`/`&[u8]` and the need to mutate the data (e.g. when masking it). I.e. `Sender::send_text` and `Sender::send_binary` (which accept immutable slices) need to mask a copy of the argument slice. Where this is too expensive, applications can use `Sender::send_binary_mut` which masks the data in-place.

Other changes:

- The `validate_utf8` setting has been removed. As `Data` only offers a byte slice view, applications need to perform the check anyway.
- A flag `has_extensions` has been added as an optimisation. If false, `Sender` and `Receiver` never have to compete for the lock only to find the collection to be empty.
