### PR TITLE
Allow buffer extraction from handshake types.

### DIFF
--- a/src/handshake/client.rs
+++ b/src/handshake/client.rs
@@ -70,9 +70,15 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Client<'a, T> {
         }
     }
 
+    /// Override the buffer to use for request/response handling.
     pub fn set_buffer(&mut self, b: BytesMut) -> &mut Self {
         self.buffer = crate::Buffer::from(b);
         self
+    }
+
+    /// Extract the buffer.
+    pub fn take_buffer(&mut self) -> BytesMut {
+        self.buffer.take().into_bytes()
     }
 
     /// Set the handshake origin header.

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -56,9 +56,15 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Server<'a, T> {
         }
     }
 
+    /// Override the buffer to use for request/response handling.
     pub fn set_buffer(&mut self, b: BytesMut) -> &mut Self {
         self.buffer = crate::Buffer::from(b);
         self
+    }
+
+    /// Extract the buffer.
+    pub fn take_buffer(&mut self) -> BytesMut {
+        self.buffer.take().into_bytes()
     }
 
     /// Add a protocol the server supports.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,7 +202,6 @@ impl Buffer {
     }
 
     /// Return all bytes from `self`, leaving it empty.
-    #[cfg(feature = "deflate")]
     pub(crate) fn take(&mut self) -> Self {
         self.split_to(self.0.len())
     }


### PR DESCRIPTION
This may be useful for applications that want to attempt a handshake but fall back to some other means of communication if the handshake fails. In the latter case they need access to the data already read from the socket.