### PR TITLE
Add an `into_inner` function to the handshake client/server that returns the inner socket.

### DIFF
--- a/src/handshake/client.rs
+++ b/src/handshake/client.rs
@@ -70,6 +70,11 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Client<'a, T> {
         }
     }
 
+    /// Get out the inner socket of the client.
+    pub fn into_inner(self) -> T {
+        self.socket
+    }
+
     /// Override the buffer to use for request/response handling.
     pub fn set_buffer(&mut self, b: BytesMut) -> &mut Self {
         self.buffer = crate::Buffer::from(b);

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -56,6 +56,7 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Server<'a, T> {
         }
     }
 
+    /// Get out the inner socket of the server.
     pub fn into_inner(self) -> T {
         self.socket
     }

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -56,6 +56,10 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Server<'a, T> {
         }
     }
 
+    pub fn into_inner(self) -> T {
+        self.socket
+    }
+
     /// Override the buffer to use for request/response handling.
     pub fn set_buffer(&mut self, b: BytesMut) -> &mut Self {
         self.buffer = crate::Buffer::from(b);


### PR DESCRIPTION
In the event that handshaking fails, it would be nice to be able to get the inner socket out of the server struct, so that it can be re-used.