### PR TITLE
Fix bug when encoding header.

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -513,7 +513,7 @@ impl Codec {
             second_byte |= EIGHT_EXT;
             self.header_buffer[offset] = second_byte;
             offset += 1;
-            self.header_buffer[offset .. offset + 8].copy_from_slice(&len.to_be_bytes());
+            self.header_buffer[offset .. offset + 8].copy_from_slice(&as_u64(len).to_be_bytes());
             offset += 8;
         }
 


### PR DESCRIPTION
The current implementation assumes that `size_of::<usize>()` == 8 which is not true of course on non-64bit architectures. To copy the expected 8 bytes we need to cast the payload len usize value to `u64`.

For context see: https://github.com/paritytech/substrate/issues/4702