### PR TITLE
Remove unsafe code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.4.0
+
+- Remove all `unsafe` code blocks.
+- Remove internal use of `futures::io::BufWriter`.
+- `Extension::decode` now takes a `&mut Vec<u8>` instead of a `BytesMut`.
+- `Incoming::Pong` contains the PONG payload data slice inline.
+- `Data` not longer contains application data, but reports only the number
+  of bytes. The actual data is written directly into the `&mut Vec<u8>`
+  parameter of `Receiver::receive` or `Receiver::receive_data`.
+- `Receiver::into_stream` has been removed.
+
 # 0.3.2
 
 - Bugfix release. `Codec::encode_header` contained a hidden assumption that

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soketto"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Parity Technologies <admin@parity.io>", "Jason Ozias <jason.g.ozias@gmail.com>"]
 description = "A websocket protocol implementation."
 keywords = ["websocket", "codec", "async", "futures"]
@@ -17,20 +17,15 @@ all-features = true
 deflate = ["flate2"]
 
 [dependencies]
-base64 = "0.11"
+base64 = "0.12"
 bytes = "0.5"
 flate2 = { version = "1.0.13", features = ["zlib"], default-features = false, optional = true }
 futures = { version = "0.3.1", features = ["unstable", "bilock"] }
-http = "0.2"
 httparse = "1.3.4"
 log = "0.4.8"
 rand = "0.7"
-sha1 = "0.6"
-smallvec = "1"
-static_assertions = "1.1"
-thiserror = "1"
+sha-1 = "0.8"
 
 [dev-dependencies]
-assert_matches = "1.3"
 async-std = "1"
 quickcheck = "0.9"

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -9,20 +9,15 @@
 //! A persistent websocket connection after the handshake phase, represented
 //! as a [`Sender`] and [`Receiver`] pair.
 
-use bytes::BytesMut;
+use bytes::{Buf, BytesMut};
 use crate::{Storage, Parsing, base::{self, Header, MAX_HEADER_SIZE, OpCode}, extension::Extension};
 use crate::data::{ByteSlice125, Data, Incoming};
-use futures::{io::{BufWriter, ReadHalf, WriteHalf}, lock::BiLock, prelude::*, stream};
-use smallvec::SmallVec;
-use static_assertions::const_assert;
-use std::io;
+use futures::{io::{ReadHalf, WriteHalf}, lock::BiLock, prelude::*};
+use std::{fmt, io, str};
 
-/// Allocation block size.
-const BLOCK_SIZE: usize = 8 * 1024;
-/// Write buffer capacity.
-const WRITE_BUFFER_SIZE: usize = 64 * 1024;
 /// Accumulated max. size of a complete message.
 const MAX_MESSAGE_SIZE: usize = 256 * 1024 * 1024;
+
 /// Max. size of a single message frame.
 const MAX_FRAME_SIZE: usize = MAX_MESSAGE_SIZE;
 
@@ -54,9 +49,9 @@ impl Mode {
 pub struct Sender<T> {
     mode: Mode,
     codec: base::Codec,
-    writer: BiLock<BufWriter<WriteHalf<T>>>,
-    buffer: Vec<u8>,  // mask buffer
-    extensions: BiLock<SmallVec<[Box<dyn Extension + Send>; 4]>>,
+    writer: BiLock<WriteHalf<T>>,
+    mask_buffer: Vec<u8>,
+    extensions: BiLock<Vec<Box<dyn Extension + Send>>>,
     has_extensions: bool
 }
 
@@ -66,12 +61,11 @@ pub struct Receiver<T> {
     mode: Mode,
     codec: base::Codec,
     reader: ReadHalf<T>,
-    writer: BiLock<BufWriter<WriteHalf<T>>>,
-    extensions: BiLock<SmallVec<[Box<dyn Extension + Send>; 4]>>,
+    writer: BiLock<WriteHalf<T>>,
+    extensions: BiLock<Vec<Box<dyn Extension + Send>>>,
     has_extensions: bool,
-    buffer: crate::Buffer, // read buffer
-    message: BytesMut, // message buffer (concatenated fragment payloads)
-    mask_buffer: Vec<u8>,
+    buffer: BytesMut,
+    ctrl_buffer: BytesMut,
     max_message_size: usize,
     is_closed: bool
 }
@@ -86,8 +80,8 @@ pub struct Builder<T> {
     mode: Mode,
     socket: T,
     codec: base::Codec,
-    extensions: SmallVec<[Box<dyn Extension + Send>; 4]>,
-    buffer: crate::Buffer,
+    extensions: Vec<Box<dyn Extension + Send>>,
+    buffer: BytesMut,
     max_message_size: usize
 }
 
@@ -107,15 +101,15 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Builder<T> {
             mode,
             socket,
             codec,
-            extensions: SmallVec::new(),
-            buffer: crate::Buffer::new(),
+            extensions: Vec::new(),
+            buffer: BytesMut::new(),
             max_message_size: MAX_MESSAGE_SIZE
         }
     }
 
     /// Set a custom buffer to use.
     pub fn set_buffer(&mut self, b: BytesMut) {
-        self.buffer = crate::Buffer::from(b)
+        self.buffer = b
     }
 
     /// Add extensions to use with this connection.
@@ -150,7 +144,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Builder<T> {
     /// Create a configured [`Sender`]/[`Receiver`] pair.
     pub fn finish(self) -> (Sender<T>, Receiver<T>) {
         let (rhlf, whlf) = self.socket.split();
-        let (wrt1, wrt2) = BiLock::new(BufWriter::with_capacity(WRITE_BUFFER_SIZE, whlf));
+        let (wrt1, wrt2) = BiLock::new(whlf);
         let has_extensions = !self.extensions.is_empty();
         let (ext1, ext2) = BiLock::new(self.extensions);
 
@@ -162,8 +156,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Builder<T> {
             extensions: ext1,
             has_extensions,
             buffer: self.buffer,
-            message: BytesMut::new(),
-            mask_buffer: Vec::new(),
+            ctrl_buffer: BytesMut::new(),
             max_message_size: self.max_message_size,
             is_closed: false
         };
@@ -171,7 +164,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Builder<T> {
         let send = Sender {
             mode: self.mode,
             writer: wrt2,
-            buffer: Vec::new(),
+            mask_buffer: Vec::new(),
             codec: self.codec,
             extensions: ext2,
             has_extensions
@@ -184,42 +177,78 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Builder<T> {
 impl<T: AsyncRead + AsyncWrite + Unpin> Receiver<T> {
     /// Receive the next websocket message.
     ///
-    /// Fragmented messages will be concatenated and returned as one block.
-    pub async fn receive(&mut self) -> Result<Incoming, Error> {
+    /// The received frames forming the complete message will be appended to
+    /// the given `message` argument. The returned [`Incoming`] value describes
+    /// the type of data that was received, e.g. binary or textual data.
+    ///
+    /// Interleaved PONG frames are returned immediately as `Data::Pong`
+    /// values. If PONGs are not expected or uninteresting,
+    /// [`Receiver::receive_data`] may be used instead which skips over PONGs
+    /// and considers only application payload data.
+    pub async fn receive(&mut self, message: &mut Vec<u8>) -> Result<Incoming<'_>, Error> {
         let mut first_fragment_opcode = None;
+        let mut length: usize = 0;
+        let message_len = message.len();
         loop {
             if self.is_closed {
                 log::debug!("can not receive, connection is closed");
                 return Err(Error::Closed)
             }
 
+            self.ctrl_buffer.clear();
             let mut header = self.receive_header().await?;
             log::trace!("recv: {}", header);
 
             // Handle control frames.
             if header.opcode().is_control() {
                 self.read_buffer(&header).await?;
-                let mut data = self.buffer.split_to(header.payload_len());
-                base::Codec::apply_mask(&header, data.as_mut());
+                self.ctrl_buffer = self.buffer.split_to(header.payload_len());
+                base::Codec::apply_mask(&header, &mut self.ctrl_buffer);
                 if header.opcode() == OpCode::Pong {
-                    return Ok(Incoming::Pong(Data::binary(data.into_bytes())))
+                    return Ok(Incoming::Pong(&self.ctrl_buffer[..]))
                 }
-                self.on_control(&header, &mut Storage::Owned(data.into_bytes())).await?;
+                self.on_control(&header).await?;
                 continue
             }
 
+            length = length.saturating_add(header.payload_len());
+
             // Check if total message does not exceed maximum.
-            if header.payload_len() + self.message.len() > self.max_message_size {
+            if length > self.max_message_size {
                 log::warn!("accumulated message length exceeds maximum");
-                return Err(Error::MessageTooLarge {
-                    current: self.message.len() + header.payload_len(),
-                    maximum: self.max_message_size
-                })
+                return Err(Error::MessageTooLarge { current: length, maximum: self.max_message_size })
             }
 
-            self.read_buffer(&header).await?;
-            base::Codec::apply_mask(&header, &mut self.buffer.as_mut()[.. header.payload_len()]);
-            self.message.unsplit(self.buffer.split_to(header.payload_len()).into_bytes());
+            // Get the frame's payload data bytes from buffer or socket.
+            {
+                let old_msg_len = message.len();
+
+                let bytes_to_read = {
+                    let required = header.payload_len();
+                    let buffered = self.buffer.len();
+
+                    if buffered == 0 {
+                        required
+                    } else if required > buffered {
+                        message.extend_from_slice(&self.buffer);
+                        self.buffer.clear();
+                        required - buffered
+                    } else {
+                        message.extend_from_slice(&self.buffer.split_to(required));
+                        0
+                    }
+                };
+
+                if bytes_to_read > 0 {
+                    let n = message.len();
+                    message.resize(n + bytes_to_read, 0u8);
+                    self.reader.read_exact(&mut message[n ..]).await?
+                }
+
+                debug_assert_eq!(header.payload_len(), message.len() - old_msg_len);
+
+                base::Codec::apply_mask(&header, &mut message[old_msg_len ..]);
+            }
 
             match (header.is_fin(), header.opcode()) {
                 (false, OpCode::Continue) => { // Intermediate message fragment.
@@ -235,14 +264,14 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Receiver<T> {
                         return Err(Error::UnexpectedOpCode(oc))
                     }
                     first_fragment_opcode = Some(oc);
-                    self.decode_with_extensions(&mut header).await?;
+                    self.decode_with_extensions(&mut header, message).await?;
                     continue
                 }
                 (true, OpCode::Continue) => { // Last message fragment.
                     if let Some(oc) = first_fragment_opcode.take() {
-                        header.set_payload_len(self.message.len());
-                        log::trace!("last fragement: total length = {} bytes", self.message.len());
-                        self.decode_with_extensions(&mut header).await?;
+                        header.set_payload_len(message.len());
+                        log::trace!("last fragement: total length = {} bytes", message.len());
+                        self.decode_with_extensions(&mut header, message).await?;
                         header.set_opcode(oc);
                     } else {
                         log::debug!("last continue frame while not processing message fragments");
@@ -254,24 +283,24 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Receiver<T> {
                         log::debug!("regular message while processing fragmented message");
                         return Err(Error::UnexpectedOpCode(oc))
                     }
-                    self.decode_with_extensions(&mut header).await?
+                    self.decode_with_extensions(&mut header, message).await?
                 }
             }
 
-            if header.opcode() == OpCode::Text {
-                return Ok(Incoming::Data(Data::text(crate::take(&mut self.message))))
-            }
+            let num_bytes = message.len() - message_len;
 
-            return Ok(Incoming::Data(Data::binary(crate::take(&mut self.message))))
+            if header.opcode() == OpCode::Text {
+                return Ok(Incoming::Data(Data::Text(num_bytes)))
+            } else {
+                return Ok(Incoming::Data(Data::Binary(num_bytes)))
+            }
         }
     }
 
     /// Receive the next websocket message, skipping over control frames.
-    ///
-    /// Fragmented messages will be concatenated and returned as one block.
-    pub async fn receive_data(&mut self) -> Result<Data, Error> {
+    pub async fn receive_data(&mut self, message: &mut Vec<u8>) -> Result<Data, Error> {
         loop {
-            if let Incoming::Data(d) = self.receive().await? {
+            if let Incoming::Data(d) = self.receive(message).await? {
                 return Ok(d)
             }
         }
@@ -279,63 +308,55 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Receiver<T> {
 
     /// Read the next frame header.
     async fn receive_header(&mut self) -> Result<Header, Error> {
-        if self.buffer.len() < MAX_HEADER_SIZE && self.buffer.remaining_mut() < MAX_HEADER_SIZE {
-            // We may not have enough data in our read buffer and there may
-            // not be enough capacity to read the next header, so reserve
-            // some extra space to make sure we can read as much.
-            const_assert!(MAX_HEADER_SIZE < BLOCK_SIZE);
-            self.buffer.reserve(BLOCK_SIZE)
-        }
         loop {
-            match self.codec.decode_header(self.buffer.as_ref())? {
+            match self.codec.decode_header(&self.buffer)? {
                 Parsing::Done { value: header, offset } => {
                     debug_assert!(offset <= MAX_HEADER_SIZE);
-                    self.buffer.split_to(offset);
+                    self.buffer.advance(offset);
                     return Ok(header)
                 }
-                Parsing::NeedMore(_) => self.buffer.read_from(&mut self.reader).await?
+                Parsing::NeedMore(n) => {
+                    crate::read(&mut self.reader, &mut self.buffer, n).await?
+                }
             }
         }
     }
 
-    /// Read more data into read buffer if necessary.
+    /// Read the complete payload data into the read buffer.
     async fn read_buffer(&mut self, header: &Header) -> Result<(), Error> {
         if header.payload_len() <= self.buffer.len() {
-            return Ok(()) // We have enough data in our buffer.
+            return Ok(())
         }
-
-        // We need to read data from the socket.
-        // Ensure we have enough capacity and ask for at least a single block
-        // so that we read a substantial amount.
-        let add = std::cmp::max(BLOCK_SIZE, header.payload_len() - self.buffer.len());
-        self.buffer.reserve(add);
-
-        while self.buffer.len() < header.payload_len() {
-            self.buffer.read_from(&mut self.reader).await?
-        }
-
+        let i = self.buffer.len();
+        let d = header.payload_len() - i;
+        self.buffer.resize(i + d, 0u8);
+        self.reader.read_exact(&mut self.buffer[i ..]).await?;
         Ok(())
     }
 
     /// Answer incoming control frames.
-    async fn on_control(&mut self, header: &Header, data: &mut Storage<'_>) -> Result<(), Error> {
-        debug_assert_eq!(data.as_ref().len(), header.payload_len());
+    async fn on_control(&mut self, header: &Header) -> Result<(), Error> {
         match header.opcode() {
             OpCode::Ping => {
                 let mut answer = Header::new(OpCode::Pong);
-                self.write(&mut answer, data).await?;
+                let mut unused = Vec::new();
+                let mut data = Storage::Unique(&mut self.ctrl_buffer);
+                write(self.mode, &mut self.codec, &mut self.writer, &mut answer, &mut data, &mut unused).await?;
                 self.flush().await?;
                 Ok(())
             }
             OpCode::Pong => Ok(()),
             OpCode::Close => {
                 self.is_closed = true;
-                let (mut header, code) = close_answer(data.as_ref())?;
+                let (mut header, code) = close_answer(&self.ctrl_buffer)?;
+                let mut unused = Vec::new();
                 if let Some(c) = code {
-                    let data = c.to_be_bytes();
-                    self.write(&mut header, &mut Storage::Shared(&data[..])).await?
+                    let mut data = c.to_be_bytes();
+                    let mut data = Storage::Unique(&mut data);
+                    write(self.mode, &mut self.codec, &mut self.writer, &mut header, &mut data, &mut unused).await?
                 } else {
-                    self.write(&mut header, &mut Storage::Shared(&[])).await?
+                    let mut data = Storage::Unique(&mut []);
+                    write(self.mode, &mut self.codec, &mut self.writer, &mut header, &mut data, &mut unused).await?
                 }
                 self.flush().await?;
                 self.writer.lock().await.close().await.or(Err(Error::Closed))
@@ -357,13 +378,13 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Receiver<T> {
     }
 
     /// Apply all extensions to the given header and the internal message buffer.
-    async fn decode_with_extensions(&mut self, header: &mut Header) -> Result<(), Error> {
+    async fn decode_with_extensions(&mut self, header: &mut Header, message: &mut Vec<u8>) -> Result<(), Error> {
         if !self.has_extensions {
             return Ok(())
         }
         for e in self.extensions.lock().await.iter_mut() {
             log::trace!("decoding with extension: {}", e.name());
-            e.decode(header, &mut self.message).map_err(Error::Extension)?
+            e.decode(header, message).map_err(Error::Extension)?
         }
         Ok(())
     }
@@ -375,14 +396,6 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Receiver<T> {
             return Ok(())
         }
         self.writer.lock().await.flush().await.or(Err(Error::Closed))
-    }
-
-    /// Write final header and payload data to socket.
-    ///
-    /// The data will be masked if necessary.
-    /// No extensions will be applied to header and payload data.
-    async fn write(&mut self, header: &mut Header, data: &mut Storage<'_>) -> Result<(), Error> {
-        write(self.mode, &mut self.codec, &mut self.writer, header, data, &mut self.mask_buffer).await
     }
 }
 
@@ -457,7 +470,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Sender<T> {
     /// The data will be masked if necessary.
     /// No extensions will be applied to header and payload data.
     async fn write(&mut self, header: &mut Header, data: &mut Storage<'_>) -> Result<(), Error> {
-        write(self.mode, &mut self.codec, &mut self.writer, header, data, &mut self.buffer).await
+        write(self.mode, &mut self.codec, &mut self.writer, header, data, &mut self.mask_buffer).await
     }
 }
 
@@ -465,7 +478,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Sender<T> {
 async fn write<T: AsyncWrite + Unpin>
     ( mode: Mode
     , codec: &mut base::Codec
-    , writer: &mut BiLock<BufWriter<WriteHalf<T>>>
+    , writer: &mut BiLock<WriteHalf<T>>
     , header: &mut Header
     , data: &mut Storage<'_>
     , mask_buffer: &mut Vec<u8>
@@ -522,51 +535,60 @@ fn close_answer(data: &[u8]) -> Result<(Header, Option<u16>), Error> {
     }
 }
 
-/// Turn a [`Receiver`] into a [`futures::Stream`].
-pub fn into_stream<T>(r: Receiver<T>) -> impl stream::Stream<Item = Result<Incoming, Error>>
-where
-    T: AsyncRead + AsyncWrite + Unpin
-{
-    stream::unfold(r, |mut r| async {
-        match r.receive().await {
-            Ok(item) => Some((Ok(item), r)),
-            Err(Error::Closed) => None,
-            Err(e) => Some((Err(e), r))
-        }
-    })
-}
-
 /// Errors which may occur when sending or receiving messages.
 #[non_exhaustive]
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug)]
 pub enum Error {
     /// An I/O error was encountered.
-    #[error("i/o error: {0}")]
-    Io(#[source] io::Error),
-
+    Io(io::Error),
     /// The base codec errored.
-    #[error("codec error: {0}")]
-    Codec(#[from] base::Error),
-
+    Codec(base::Error),
     /// An extension produced an error while encoding or decoding.
-    #[error("extension error: {0}")]
-    Extension(#[source] crate::BoxedError),
-
+    Extension(crate::BoxedError),
     /// An unexpected opcode was encountered.
-    #[error("unexpected opcode: {0}")]
     UnexpectedOpCode(OpCode),
-
     /// A close reason was not correctly UTF-8 encoded.
-    #[error("utf-8 opcode: {0}")]
-    Utf8(#[from] std::str::Utf8Error),
-
+    Utf8(str::Utf8Error),
     /// The total message payload data size exceeds the configured maximum.
-    #[error("message too large: len >= {current}, maximum = {maximum}")]
     MessageTooLarge { current: usize, maximum: usize },
-
     /// The connection is closed.
-    #[error("connection closed")]
     Closed
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::Io(e) =>
+                write!(f, "i/o error: {}", e),
+            Error::Codec(e) =>
+                write!(f, "codec error: {}", e),
+            Error::Extension(e) =>
+                write!(f, "extension error: {}", e),
+            Error::UnexpectedOpCode(c) =>
+                write!(f, "unexpected opcode: {}", c),
+            Error::Utf8(e) =>
+                write!(f, "utf-8 error: {}", e),
+            Error::MessageTooLarge { current, maximum } =>
+                write!(f, "message too large: len >= {}, maximum = {}", current, maximum),
+            Error::Closed =>
+                f.write_str("connection closed")
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Io(e) => Some(e),
+            Error::Codec(e) => Some(e),
+            Error::Extension(e) => Some(&**e),
+            Error::Utf8(e) => Some(e),
+            Error::UnexpectedOpCode(_)
+            | Error::MessageTooLarge {..}
+            | Error::Closed
+            => None
+        }
+    }
 }
 
 impl From<io::Error> for Error {
@@ -578,3 +600,16 @@ impl From<io::Error> for Error {
         }
     }
 }
+
+impl From<str::Utf8Error> for Error {
+    fn from(e: str::Utf8Error) -> Self {
+        Error::Utf8(e)
+    }
+}
+
+impl From<base::Error> for Error {
+    fn from(e: base::Error) -> Self {
+        Error::Codec(e)
+    }
+}
+

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -270,7 +270,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Receiver<T> {
                 (true, OpCode::Continue) => { // Last message fragment.
                     if let Some(oc) = first_fragment_opcode.take() {
                         header.set_payload_len(message.len());
-                        log::trace!("last fragement: total length = {} bytes", message.len());
+                        log::trace!("last fragment: total length = {} bytes", message.len());
                         self.decode_with_extensions(&mut header, message).await?;
                         header.set_opcode(oc);
                     } else {
@@ -612,4 +612,3 @@ impl From<base::Error> for Error {
         Error::Codec(e)
     }
 }
-

--- a/src/data.rs
+++ b/src/data.rs
@@ -8,19 +8,18 @@
 
 //! Types describing various forms of payload data.
 
-use bytes::BytesMut;
-use std::convert::TryFrom;
+use std::{convert::TryFrom, fmt};
 
 /// Data received from the remote end.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum Incoming {
+pub enum Incoming<'a> {
     /// Text or binary data.
     Data(Data),
     /// Data sent with a PONG control frame.
-    Pong(Data)
+    Pong(&'a [u8])
 }
 
-impl Incoming {
+impl Incoming<'_> {
     /// Is this text or binary data?
     pub fn is_data(&self) -> bool {
         if let Incoming::Data(_) = self { true } else { false }
@@ -48,97 +47,59 @@ impl Incoming {
             false
         }
     }
-}
 
-impl AsRef<[u8]> for Incoming {
-    fn as_ref(&self) -> &[u8] {
+    /// The length of data (number of bytes).
+    pub fn len(&self) -> usize {
         match self {
-            Incoming::Data(d) => d.as_ref(),
-            Incoming::Pong(d) => d.as_ref()
+            Incoming::Data(d) => d.len(),
+            Incoming::Pong(d) => d.len()
         }
     }
 }
-
-impl AsMut<[u8]> for Incoming {
-    fn as_mut(&mut self) -> &mut [u8] {
-        match self {
-            Incoming::Data(d) => d.as_mut(),
-            Incoming::Pong(d) => d.as_mut()
-        }
-    }
-}
-
-impl Into<Data> for Incoming {
-    fn into(self: Incoming) -> Data {
-        match self {
-            Incoming::Data(d) => d,
-            Incoming::Pong(d) => d
-        }
-    }
-}
-
-/// Application data.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Data(DataRepr);
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-enum DataRepr {
-    /// Binary data.
-    Binary(BytesMut),
-    /// UTF-8 encoded data.
-    Text(BytesMut)
+pub enum Data {
+    /// Textual data (number of bytes).
+    Text(usize),
+    /// Binary data (number of bytes).
+    Binary(usize)
 }
 
 impl Data {
-    /// Create a new binary `Data` value.
-    pub(crate) fn binary(b: BytesMut) -> Self {
-        Data(DataRepr::Binary(b))
-    }
-
-    /// Create a new textual `Data` value.
-    pub(crate) fn text(b: BytesMut) -> Self {
-        Data(DataRepr::Text(b))
+    /// Is this text data?
+    pub fn is_text(&self) -> bool {
+        if let Data::Text(_) = self { true } else { false }
     }
 
     /// Is this binary data?
     pub fn is_binary(&self) -> bool {
-        if let DataRepr::Binary(_) = self.0 { true } else { false }
+        if let Data::Binary(_) = self { true } else { false }
     }
 
-    /// Is this UTF-8 encoded textual data?
-    pub fn is_text(&self) -> bool {
-        if let DataRepr::Text(_) = self.0 { true } else { false }
-    }
-}
-
-impl AsRef<[u8]> for Data {
-    fn as_ref(&self) -> &[u8] {
-        match &self.0 {
-            DataRepr::Binary(d) => d,
-            DataRepr::Text(d) => d
+    /// The length of data (number of bytes).
+    pub fn len(&self) -> usize {
+        match self {
+            Data::Text(n) => *n,
+            Data::Binary(n) => *n
         }
     }
 }
 
-impl AsMut<[u8]> for Data {
-    fn as_mut(&mut self) -> &mut [u8] {
-        match &mut self.0 {
-            DataRepr::Binary(d) => d,
-            DataRepr::Text(d) => d
-        }
-    }
-}
-
-/// Wrapper which restricts the length of its byte slice to 125 bytes.
+/// Wrapper type which restricts the length of its byte slice to 125 bytes.
 #[derive(Debug)]
 pub struct ByteSlice125<'a>(&'a [u8]);
 
-static_assertions::const_assert_eq!(125, crate::base::MAX_CTRL_BODY_SIZE);
-
 /// Error, if converting to [`ByteSlice125`] fails.
-#[derive(Clone, Debug, thiserror::Error)]
-#[error("Slice larger than 125 bytes")]
+#[derive(Clone, Debug)]
 pub struct SliceTooLarge(());
+
+impl fmt::Display for SliceTooLarge {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("Slice larger than 125 bytes")
+    }
+}
+
+impl std::error::Error for SliceTooLarge {}
 
 impl<'a> TryFrom<&'a [u8]> for ByteSlice125<'a> {
     type Error = SliceTooLarge;

--- a/src/extension.rs
+++ b/src/extension.rs
@@ -14,7 +14,6 @@
 #[cfg(feature = "deflate")]
 pub mod deflate;
 
-use bytes::BytesMut;
 use crate::{BoxedError, Storage, base::Header};
 use std::{borrow::Cow, fmt};
 
@@ -67,7 +66,7 @@ pub trait Extension: std::fmt::Debug {
     ///
     /// The frame header is given, as well as the accumulated payload data, i.e.
     /// the concatenated payload data of all message fragments.
-    fn decode(&mut self, header: &mut Header, data: &mut BytesMut) -> Result<(), BoxedError>;
+    fn decode(&mut self, header: &mut Header, data: &mut Vec<u8>) -> Result<(), BoxedError>;
 
     /// The reserved bits this extension uses.
     fn reserved_bits(&self) -> (bool, bool, bool) {
@@ -96,7 +95,7 @@ impl<E: Extension + ?Sized> Extension for Box<E> {
         (**self).encode(header, data)
     }
 
-    fn decode(&mut self, header: &mut Header, data: &mut BytesMut) -> Result<(), BoxedError> {
+    fn decode(&mut self, header: &mut Header, data: &mut Vec<u8>) -> Result<(), BoxedError> {
         (**self).decode(header, data)
     }
 

--- a/src/extension/deflate.rs
+++ b/src/extension/deflate.rs
@@ -10,7 +10,6 @@
 //!
 //! [rfc7692]: https://tools.ietf.org/html/rfc7692
 
-use bytes::{buf::BufMutExt, BytesMut};
 use crate::{
     as_u64,
     BoxedError,
@@ -20,8 +19,7 @@ use crate::{
     extension::{Extension, Param}
 };
 use flate2::{Compress, Compression, FlushCompress, write::DeflateDecoder};
-use smallvec::SmallVec;
-use std::{convert::TryInto, io::{self, Write}};
+use std::{convert::TryInto, io::{self, Write}, mem};
 
 const SERVER_NO_CONTEXT_TAKEOVER: &str = "server_no_context_takeover";
 const SERVER_MAX_WINDOW_BITS: &str = "server_max_window_bits";
@@ -37,8 +35,8 @@ const CLIENT_MAX_WINDOW_BITS: &str = "client_max_window_bits";
 pub struct Deflate {
     mode: Mode,
     enabled: bool,
-    buffer: crate::Buffer,
-    params: SmallVec<[Param<'static>; 2]>,
+    buffer: Vec<u8>,
+    params: Vec<Param<'static>>,
     our_max_window_bits: u8,
     their_max_window_bits: u8,
     await_last_fragment: bool
@@ -48,9 +46,9 @@ impl Deflate {
     /// Create a new deflate extension either on client or server side.
     pub fn new(mode: Mode) -> Self {
         let params = match mode {
-            Mode::Server => SmallVec::new(),
+            Mode::Server => Vec::new(),
             Mode::Client => {
-                let mut params = SmallVec::new();
+                let mut params = Vec::new();
                 params.push(Param::new(SERVER_NO_CONTEXT_TAKEOVER));
                 params.push(Param::new(CLIENT_NO_CONTEXT_TAKEOVER));
                 params.push(Param::new(CLIENT_MAX_WINDOW_BITS));
@@ -60,7 +58,7 @@ impl Deflate {
         Deflate {
             mode,
             enabled: false,
-            buffer: crate::Buffer::new(),
+            buffer: Vec::new(),
             params,
             our_max_window_bits: 15,
             their_max_window_bits: 15,
@@ -226,7 +224,7 @@ impl Extension for Deflate {
         (true, false, false)
     }
 
-    fn decode(&mut self, header: &mut Header, data: &mut BytesMut) -> Result<(), BoxedError> {
+    fn decode(&mut self, header: &mut Header, data: &mut Vec<u8>) -> Result<(), BoxedError> {
         if data.is_empty() {
             return Ok(())
         }
@@ -254,9 +252,10 @@ impl Extension for Deflate {
         data.extend_from_slice(&[0, 0, 0xFF, 0xFF]); // cf. RFC 7692, 7.2.2
 
         self.buffer.clear();
-        let mut decoder = DeflateDecoder::new(self.buffer.take().into_bytes().writer());
+        let mut decoder = DeflateDecoder::new(&mut self.buffer);
         decoder.write_all(&data)?;
-        *data = decoder.finish()?.into_inner();
+        decoder.finish()?;
+        mem::swap(data, &mut self.buffer);
 
         header.set_rsv1(false);
         header.set_payload_len(data.len());
@@ -277,39 +276,42 @@ impl Extension for Deflate {
         }
 
         self.buffer.clear();
+        self.buffer.resize(data.as_ref().len(), 0u8);
 
         let mut encoder =
             Compress::new_with_window_bits(Compression::fast(), false, self.our_max_window_bits);
 
         // Compress all input bytes.
         while encoder.total_in() < as_u64(data.as_ref().len()) {
-            let off: usize = encoder.total_in().try_into()?;
-            self.buffer.reserve(data.as_ref().len() - off);
-            let n = encoder.total_out();
-            encoder.compress(&data.as_ref()[off ..], self.buffer.bytes_mut(), FlushCompress::Sync)?;
-            self.buffer.advance_mut((encoder.total_out() - n).try_into()?)
+            let k: usize = encoder.total_in().try_into()?;
+            let n: usize = encoder.total_out().try_into()?;
+            encoder.compress(&data.as_ref()[k ..], &mut self.buffer[n ..], FlushCompress::Sync)?;
         }
 
+        self.buffer.truncate(encoder.total_out().try_into()?);
+
         // We need to append an empty deflate block if not there yet (RFC 7692, 7.2.1).
-        if !self.buffer.as_ref().ends_with(&[0, 0, 0xFF, 0xFF]) {
-            self.buffer.reserve(5); // Make sure there is room for the trailing end bytes.
-            let n = encoder.total_out();
-            encoder.compress(&[], self.buffer.bytes_mut(), FlushCompress::Sync)?;
-            self.buffer.advance_mut((encoder.total_out() - n).try_into()?)
+        if !self.buffer.ends_with(&[0, 0, 0xFF, 0xFF]) {
+            let i = self.buffer.len();
+            self.buffer.resize(i + 16, 0u8); // Make sure there is room for the trailing end bytes.
+            encoder.compress(&[], &mut self.buffer[i ..], FlushCompress::Sync)?;
+            self.buffer.truncate(encoder.total_out().try_into()?)
         }
 
         // If we still have not seen the empty deflate block appended, something is wrong.
-        if !self.buffer.as_ref().ends_with(&[0, 0, 0xFF, 0xFF]) {
+        if !self.buffer.ends_with(&[0, 0, 0xFF, 0xFF]) {
             log::error!("missing 00 00 FF FF");
             return Err(io::Error::new(io::ErrorKind::Other, "missing 00 00 FF FF").into())
         }
 
         self.buffer.truncate(self.buffer.len() - 4); // Remove 00 00 FF FF; cf. RFC 7692, 7.2.1
-        let compressed = self.buffer.take().into_bytes();
+        if let Storage::Owned(d) = data {
+            mem::swap(d, &mut self.buffer)
+        } else {
+            *data = Storage::Owned(mem::take(&mut self.buffer))
+        }
         header.set_rsv1(true);
-        header.set_payload_len(compressed.len());
-        *data = Storage::Owned(compressed);
-
+        header.set_payload_len(data.as_ref().len());
         Ok(())
     }
 }

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -10,14 +10,12 @@
 //!
 //! [handshake]: https://tools.ietf.org/html/rfc6455#section-4
 
-use bytes::BytesMut;
+use bytes::{Buf, BytesMut};
 use crate::{Parsing, extension::Extension};
 use crate::connection::{self, Mode};
 use futures::prelude::*;
-use http::StatusCode;
-use sha1::Sha1;
-use smallvec::SmallVec;
-use std::str;
+use sha1::{Digest, Sha1};
+use std::{mem, str};
 use super::{
     Error,
     KEY,
@@ -38,11 +36,11 @@ const SOKETTO_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub struct Server<'a, T> {
     socket: T,
     /// Protocols the server supports.
-    protocols: SmallVec<[&'a str; 4]>,
+    protocols: Vec<&'a str>,
     /// Extensions the server supports.
-    extensions: SmallVec<[Box<dyn Extension + Send>; 4]>,
-    /// Encoding/decoding buffer
-    buffer: crate::Buffer
+    extensions: Vec<Box<dyn Extension + Send>>,
+    /// Encoding/decoding buffer.
+    buffer: BytesMut
 }
 
 impl<'a, T: AsyncRead + AsyncWrite + Unpin> Server<'a, T> {
@@ -50,21 +48,21 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Server<'a, T> {
     pub fn new(socket: T) -> Self {
         Server {
             socket,
-            protocols: SmallVec::new(),
-            extensions: SmallVec::new(),
-            buffer: crate::Buffer::new()
+            protocols: Vec::new(),
+            extensions: Vec::new(),
+            buffer: BytesMut::new()
         }
     }
 
     /// Override the buffer to use for request/response handling.
     pub fn set_buffer(&mut self, b: BytesMut) -> &mut Self {
-        self.buffer = crate::Buffer::from(b);
+        self.buffer = b;
         self
     }
 
     /// Extract the buffer.
     pub fn take_buffer(&mut self) -> BytesMut {
-        self.buffer.take().into_bytes()
+        mem::take(&mut self.buffer)
     }
 
     /// Add a protocol the server supports.
@@ -88,12 +86,9 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Server<'a, T> {
     pub async fn receive_request(&mut self) -> Result<ClientRequest<'a>, Error> {
         self.buffer.clear();
         loop {
-            if self.buffer.remaining_mut() < BLOCK_SIZE {
-                self.buffer.reserve(BLOCK_SIZE)
-            }
-            self.buffer.read_from(&mut self.socket).await?;
+            crate::read(&mut self.socket, &mut self.buffer, BLOCK_SIZE).await?;
             if let Parsing::Done { value, offset } = self.decode_request()? {
-                self.buffer.split_to(offset);
+                self.buffer.advance(offset);
                 return Ok(value)
             }
         }
@@ -103,7 +98,7 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Server<'a, T> {
     pub async fn send_response(&mut self, r: &Response<'_>) -> Result<(), Error> {
         self.buffer.clear();
         self.encode_response(r);
-        self.socket.write_all(self.buffer.as_ref()).await?;
+        self.socket.write_all(&self.buffer).await?;
         self.socket.flush().await?;
         self.buffer.clear();
         Ok(())
@@ -112,7 +107,7 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Server<'a, T> {
     /// Turn this handshake into a [`connection::Builder`].
     pub fn into_builder(mut self) -> connection::Builder<T> {
         let mut builder = connection::Builder::new(self.socket, Mode::Server);
-        builder.set_buffer(self.buffer.into_bytes());
+        builder.set_buffer(self.buffer);
         builder.add_extensions(self.extensions.drain(..));
         builder
     }
@@ -157,7 +152,7 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Server<'a, T> {
             configure_extensions(&mut self.extensions, std::str::from_utf8(h.value)?)?
         }
 
-        let mut protocols = SmallVec::new();
+        let mut protocols = Vec::new();
         for p in request.headers.iter()
             .filter(|h| h.name.eq_ignore_ascii_case(SEC_WEBSOCKET_PROTOCOL))
         {
@@ -176,9 +171,9 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Server<'a, T> {
                 let mut key_buf = [0; 32];
                 let accept_value = {
                     let mut digest = Sha1::new();
-                    digest.update(key);
-                    digest.update(KEY);
-                    let d = digest.digest().bytes();
+                    digest.input(key);
+                    digest.input(KEY);
+                    let d = digest.result();
                     let n = base64::encode_config_slice(&d, base64::STANDARD, &mut key_buf);
                     &key_buf[.. n]
                 };
@@ -197,11 +192,15 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Server<'a, T> {
             }
             Response::Reject { status_code } => {
                 self.buffer.extend_from_slice(b"HTTP/1.1 ");
-                let s = StatusCode::from_u16(*status_code)
-                    .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-                self.buffer.extend_from_slice(s.as_str().as_bytes());
+                let (_, s, reason) =
+                    if let Ok(i) = STATUSCODES.binary_search_by_key(status_code, |(n, _, _)| *n) {
+                        STATUSCODES[i]
+                    } else {
+                        (500, "500", "Internal Server Error")
+                    };
+                self.buffer.extend_from_slice(s.as_bytes());
                 self.buffer.extend_from_slice(b" ");
-                self.buffer.extend_from_slice(s.canonical_reason().unwrap_or("N/A").as_bytes());
+                self.buffer.extend_from_slice(reason.as_bytes());
                 self.buffer.extend_from_slice(b"\r\n\r\n")
             }
         }
@@ -212,7 +211,7 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Server<'a, T> {
 #[derive(Debug)]
 pub struct ClientRequest<'a> {
     ws_key: Vec<u8>,
-    protocols: SmallVec<[&'a str; 4]>
+    protocols: Vec<&'a str>
 }
 
 impl<'a> ClientRequest<'a> {
@@ -244,4 +243,68 @@ pub enum Response<'a> {
         status_code: u16
     }
 }
+
+/// Known status codes and their reason phrases.
+const STATUSCODES: &[(u16, &str, &str)] = &[
+    (100, "100", "Continue"),
+    (101, "101", "Switching Protocols"),
+    (102, "102", "Processing"),
+    (200, "200", "OK"),
+    (201, "201", "Created"),
+    (202, "202", "Accepted"),
+    (203, "203", "Non Authoritative Information"),
+    (204, "204", "No Content"),
+    (205, "205", "Reset Content"),
+    (206, "206", "Partial Content"),
+    (207, "207", "Multi-Status"),
+    (208, "208", "Already Reported"),
+    (226, "226", "IM Used"),
+    (300, "300", "Multiple Choices"),
+    (301, "301", "Moved Permanently"),
+    (302, "302", "Found"),
+    (303, "303", "See Other"),
+    (304, "304", "Not Modified"),
+    (305, "305", "Use Proxy"),
+    (307, "307", "Temporary Redirect"),
+    (308, "308", "Permanent Redirect"),
+    (400, "400", "Bad Request"),
+    (401, "401", "Unauthorized"),
+    (402, "402", "Payment Required"),
+    (403, "403", "Forbidden"),
+    (404, "404", "Not Found"),
+    (405, "405", "Method Not Allowed"),
+    (406, "406", "Not Acceptable"),
+    (407, "407", "Proxy Authentication Required"),
+    (408, "408", "Request Timeout"),
+    (409, "409", "Conflict"),
+    (410, "410", "Gone"),
+    (411, "411", "Length Required"),
+    (412, "412", "Precondition Failed"),
+    (413, "413", "Payload Too Large"),
+    (414, "414", "URI Too Long"),
+    (415, "415", "Unsupported Media Type"),
+    (416, "416", "Range Not Satisfiable"),
+    (417, "417", "Expectation Failed"),
+    (418, "418", "I'm a teapot"),
+    (421, "421", "Misdirected Request"),
+    (422, "422", "Unprocessable Entity"),
+    (423, "423", "Locked"),
+    (424, "424", "Failed Dependency"),
+    (426, "426", "Upgrade Required"),
+    (428, "428", "Precondition Required"),
+    (429, "429", "Too Many Requests"),
+    (431, "431", "Request Header Fields Too Large"),
+    (451, "451", "Unavailable For Legal Reasons"),
+    (500, "500", "Internal Server Error"),
+    (501, "501", "Not Implemented"),
+    (502, "502", "Bad Gateway"),
+    (503, "503", "Service Unavailable"),
+    (504, "504", "Gateway Timeout"),
+    (505, "505", "HTTP Version Not Supported"),
+    (506, "506", "Variant Also Negotiates"),
+    (507, "507", "Insufficient Storage"),
+    (508, "508", "Loop Detected"),
+    (510, "510", "Not Extended"),
+    (511, "511", "Network Authentication Required")
+];
 


### PR DESCRIPTION
This commit contains several changes, summarised in the CHANGELOG.md. The primary focus has been the removal of all `unsafe` code blocks. `lib.rs` now features a `#![forbid(unsafe_code)]` attribute.

In addition the API changes somewhat: Application data is now read directly into provided buffers if possible. Internal buffering is minimised and client code should use `BufWriter`/`BufReader` if desired.