### PR TITLE
Use tokens for send and receive operations.

### DIFF
--- a/examples/autobahn_client.rs
+++ b/examples/autobahn_client.rs
@@ -38,9 +38,8 @@ async fn num_of_cases() -> Result<usize, BoxedError> {
     let socket = TcpStream::connect("127.0.0.1:9001").await?;
     let mut client = new_client(socket, "/getCaseCount");
     assert!(matches!(client.handshake().await?, handshake::ServerResponse::Accepted {..}));
-    let (_, mut receiver) = client.into_builder().finish();
+    let (.., mut receiver, token) = client.into_builder().finish();
     let mut data = Vec::new();
-    let token = receiver.token().unwrap();
     let kind = receiver.receive_data(token, &mut data).await?;
     assert!(kind.0.is_text());
     let num = usize::from_str(std::str::from_utf8(&data)?)?;
@@ -54,9 +53,7 @@ async fn run_case(n: usize) -> Result<(), BoxedError> {
     let socket = TcpStream::connect("127.0.0.1:9001").await?;
     let mut client = new_client(socket, &resource);
     assert!(matches!(client.handshake().await?, handshake::ServerResponse::Accepted {..}));
-    let (mut sender, mut receiver) = client.into_builder().finish();
-    let mut rtoken = receiver.token().unwrap();
-    let mut wtoken = sender.token().unwrap();
+    let (mut sender, mut wtoken, mut receiver, mut rtoken) = client.into_builder().finish();
     let mut message = Vec::new();
     loop {
         message.clear();
@@ -85,8 +82,7 @@ async fn update_report() -> Result<(), BoxedError> {
     let socket = TcpStream::connect("127.0.0.1:9001").await?;
     let mut client = new_client(socket, &resource);
     assert!(matches!(client.handshake().await?, handshake::ServerResponse::Accepted {..}));
-    let (mut sender, _) = client.into_builder().finish();
-    let token = sender.token().unwrap();
+    let (mut sender, token, ..) = client.into_builder().finish();
     sender.close(token).await?;
     Ok(())
 }

--- a/examples/autobahn_client.rs
+++ b/examples/autobahn_client.rs
@@ -40,8 +40,9 @@ async fn num_of_cases() -> Result<usize, BoxedError> {
     assert!(matches!(client.handshake().await?, handshake::ServerResponse::Accepted {..}));
     let (_, mut receiver) = client.into_builder().finish();
     let mut data = Vec::new();
-    let kind = receiver.receive_data(&mut data).await?;
-    assert!(kind.is_text());
+    let token = receiver.token().unwrap();
+    let kind = receiver.receive_data(token, &mut data).await?;
+    assert!(kind.0.is_text());
     let num = usize::from_str(std::str::from_utf8(&data)?)?;
     log::info!("{} cases to run", num);
     Ok(num)
@@ -54,19 +55,23 @@ async fn run_case(n: usize) -> Result<(), BoxedError> {
     let mut client = new_client(socket, &resource);
     assert!(matches!(client.handshake().await?, handshake::ServerResponse::Accepted {..}));
     let (mut sender, mut receiver) = client.into_builder().finish();
+    let mut rtoken = receiver.token().unwrap();
+    let mut wtoken = sender.token().unwrap();
     let mut message = Vec::new();
     loop {
         message.clear();
-        match receiver.receive_data(&mut message).await {
-            Ok(soketto::Data::Binary(n)) => {
+        match receiver.receive_data(rtoken, &mut message).await {
+            Ok((soketto::Data::Binary(n), t)) => {
                 assert_eq!(n, message.len());
-                sender.send_binary_mut(&mut message).await?;
-                sender.flush().await?
+                rtoken = t;
+                wtoken = sender.send_binary_mut(wtoken, &mut message).await?;
+                wtoken = sender.flush(wtoken).await?
             }
-            Ok(soketto::Data::Text(n)) => {
+            Ok((soketto::Data::Text(n), t)) => {
                 assert_eq!(n, message.len());
-                sender.send_text(std::str::from_utf8(&message)?).await?;
-                sender.flush().await?
+                rtoken = t;
+                wtoken = sender.send_text(wtoken, std::str::from_utf8(&message)?).await?;
+                wtoken = sender.flush(wtoken).await?
             }
             Err(connection::Error::Closed) => return Ok(()),
             Err(e) => return Err(e.into())
@@ -80,7 +85,9 @@ async fn update_report() -> Result<(), BoxedError> {
     let socket = TcpStream::connect("127.0.0.1:9001").await?;
     let mut client = new_client(socket, &resource);
     assert!(matches!(client.handshake().await?, handshake::ServerResponse::Accepted {..}));
-    client.into_builder().finish().0.close().await?;
+    let (mut sender, _) = client.into_builder().finish();
+    let token = sender.token().unwrap();
+    sender.close(token).await?;
     Ok(())
 }
 

--- a/examples/autobahn_server.rs
+++ b/examples/autobahn_server.rs
@@ -31,9 +31,7 @@ async fn main() -> Result<(), BoxedError> {
         };
         let accept = handshake::server::Response::Accept { key: &key, protocol: None };
         server.send_response(&accept).await?;
-        let (mut sender, mut receiver) = server.into_builder().finish();
-        let mut rtoken = receiver.token().unwrap();
-        let mut wtoken = sender.token().unwrap();
+        let (mut sender, mut wtoken, mut receiver, mut rtoken) = server.into_builder().finish();
         let mut message = Vec::new();
         loop {
             message.clear();

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -61,6 +61,10 @@ impl fmt::Display for Id {
 /// in order to react to control frames such as PING or CLOSE. While those will be
 /// answered transparently they have to be received in the first place, so
 /// calling [`Receiver::receive`] is imperative.
+///
+/// **NB**: Async sender methods consume and return `self` to force application
+/// code to complete the futures representing those async methods, otherwise
+/// `self` or the websocket connection could end up in an invalid state.
 #[derive(Debug)]
 pub struct Sender<T> {
     id: Id,
@@ -73,6 +77,11 @@ pub struct Sender<T> {
 }
 
 /// The receiving half of a connection.
+///
+/// **NB**: Async receiver methods consume and return `self` to force
+/// application code to complete the futures representing those async
+/// methods, otherwise `self` or the websocket connection could end up
+/// in an invalid state.
 #[derive(Debug)]
 pub struct Receiver<T> {
     id: Id,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -74,7 +74,7 @@ pub struct RecvToken(Id);
 /// not possible to only send websocket messages. Receiving data is required
 /// in order to react to control frames such as PING or CLOSE. While those will be
 /// answered transparently they have to be received in the first place, so
-/// calling [`connection::Receiver::receive`] is imperative.
+/// calling [`Receiver::receive`] is imperative.
 #[derive(Debug)]
 pub struct Sender<T> {
     id: Id,

--- a/src/data.rs
+++ b/src/data.rs
@@ -12,14 +12,14 @@ use std::{convert::TryFrom, fmt};
 
 /// Data received from the remote end.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum Incoming<'a> {
+pub enum Incoming {
     /// Text or binary data.
     Data(Data),
     /// Data sent with a PONG control frame.
-    Pong(&'a [u8])
+    Pong(Vec<u8>)
 }
 
-impl Incoming<'_> {
+impl Incoming {
     /// Is this text or binary data?
     pub fn is_data(&self) -> bool {
         if let Incoming::Data(_) = self { true } else { false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,21 +29,20 @@
 //! let mut client = Client::new(socket.compat(), "...", "/");
 //!
 //! // And finally we perform the handshake and handle the result.
-//! let (mut sender, mut send_token, mut receiver, receive_token) =
-//!     match client.handshake().await? {
-//!         ServerResponse::Accepted { .. } => client.into_builder().finish(),
-//!         ServerResponse::Redirect { status_code, location } => unimplemented!("follow location URL"),
-//!         ServerResponse::Rejected { status_code } => unimplemented!("handle failure")
-//!     };
+//! let (mut sender, receiver) = match client.handshake().await? {
+//!     ServerResponse::Accepted { .. } => client.into_builder().finish(),
+//!     ServerResponse::Redirect { status_code, location } => unimplemented!("follow location URL"),
+//!     ServerResponse::Rejected { status_code } => unimplemented!("handle failure")
+//! };
 //!
 //! // Over the established websocket connection we can send
-//! send_token = sender.send_text(send_token, "some text").await?;
-//! send_token = sender.send_text(send_token, "some more text").await?;
-//! sender.flush(send_token).await?;
+//! sender = sender.send_text("some text").await?;
+//! sender = sender.send_text("some more text").await?;
+//! sender = sender.flush().await?;
 //!
 //! // ... and receive data.
 //! let mut data = Vec::new();
-//! receiver.receive_data(receive_token, &mut data).await?;
+//! receiver.receive_data(&mut data).await?;
 //!
 //! # Ok(())
 //! # }
@@ -76,18 +75,18 @@
 //!     server.send_response(&accept).await?;
 //!
 //!     // And we can finally transition to a websocket connection.
-//!     let (mut sender, mut send_token, mut receiver, receive_token) = server.into_builder().finish();
+//!     let (mut sender, receiver) = server.into_builder().finish();
 //!
 //!     let mut data = Vec::new();
-//!     let (data_type, _) = receiver.receive_data(receive_token, &mut data).await?;
+//!     let (data_type, _) = receiver.receive_data(&mut data).await?;
 //!
 //!     if data_type.is_text() {
-//!         send_token = sender.send_text(send_token, std::str::from_utf8(&data)?).await?
+//!         sender = sender.send_text(std::str::from_utf8(&data)?).await?
 //!     } else {
-//!         send_token = sender.send_binary(send_token, &data).await?
+//!         sender = sender.send_binary(&data).await?
 //!     }
 //!
-//!     sender.close(send_token).await?
+//!     sender.close().await?
 //! }
 //!
 //! # Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,20 +29,21 @@
 //! let mut client = Client::new(socket.compat(), "...", "/");
 //!
 //! // And finally we perform the handshake and handle the result.
-//! let (mut sender, mut receiver) = match client.handshake().await? {
-//!     ServerResponse::Accepted { .. } => client.into_builder().finish(),
-//!     ServerResponse::Redirect { status_code, location } => unimplemented!("follow location URL"),
-//!     ServerResponse::Rejected { status_code } => unimplemented!("handle failure")
-//! };
+//! let (mut sender, mut send_token, mut receiver, receive_token) =
+//!     match client.handshake().await? {
+//!         ServerResponse::Accepted { .. } => client.into_builder().finish(),
+//!         ServerResponse::Redirect { status_code, location } => unimplemented!("follow location URL"),
+//!         ServerResponse::Rejected { status_code } => unimplemented!("handle failure")
+//!     };
 //!
 //! // Over the established websocket connection we can send
-//! sender.send_text("some text").await?;
-//! sender.send_text("some more text").await?;
-//! sender.flush().await?;
+//! send_token = sender.send_text(send_token, "some text").await?;
+//! send_token = sender.send_text(send_token, "some more text").await?;
+//! sender.flush(send_token).await?;
 //!
 //! // ... and receive data.
 //! let mut data = Vec::new();
-//! receiver.receive_data(&mut data).await?;
+//! receiver.receive_data(receive_token, &mut data).await?;
 //!
 //! # Ok(())
 //! # }
@@ -75,18 +76,18 @@
 //!     server.send_response(&accept).await?;
 //!
 //!     // And we can finally transition to a websocket connection.
-//!     let (mut sender, mut receiver) = server.into_builder().finish();
+//!     let (mut sender, mut send_token, mut receiver, receive_token) = server.into_builder().finish();
 //!
 //!     let mut data = Vec::new();
-//!     let data_type = receiver.receive_data(&mut data).await?;
+//!     let (data_type, _) = receiver.receive_data(receive_token, &mut data).await?;
 //!
 //!     if data_type.is_text() {
-//!         sender.send_text(std::str::from_utf8(&data)?).await?
+//!         send_token = sender.send_text(send_token, std::str::from_utf8(&data)?).await?
 //!     } else {
-//!         sender.send_binary(&data).await?
+//!         send_token = sender.send_binary(send_token, &data).await?
 //!     }
 //!
-//!     sender.close().await?
+//!     sender.close(send_token).await?
 //! }
 //!
 //! # Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,15 +15,6 @@
 //! i.e. a [Sender]/[Receiver] pair and send and receive textual or
 //! binary data.
 //!
-//! **Note**: While it is possible to only receive websocket messages it is
-//! not possible to only send websocket messages. Receiving data is required
-//! in order to react to control frames such as PING or CLOSE. While those will be
-//! answered transparently they have to be received in the first place, so
-//! calling [`connection::Receiver::receive`] is imperative.
-//!
-//! **Note**: None of the `async` methods are safe to cancel so their `Future`s
-//! must not be dropped unless they return `Poll::Ready`.
-//!
 //! # Client example
 //!
 //! ```no_run


### PR DESCRIPTION
This PR sits on top of #21 (only commit 2b8aab6 is new) and adds `SendToken` and `RecvToken` as required paramters to send and receive operations. Tokens can not be copied, nor created by client code. They serve as proof that certain operations -- i.e. send or receive -- were completed successfully before called again.

Since this changes the client API quite substantially it would be nice to get some feedback regarding client API use. Instead of returning tokens when constructing the `Sender`/`Receiver` pair (which would mean returning a 4-tuple) I chose to use getter and setter methods, but maybe a 4-tuple would still be more convenient?