### PR TITLE
Make the close reason available to application code

### DIFF
--- a/examples/autobahn_client.rs
+++ b/examples/autobahn_client.rs
@@ -68,7 +68,7 @@ async fn run_case(n: usize) -> Result<(), BoxedError> {
                 sender.send_text(std::str::from_utf8(&message)?).await?;
                 sender.flush().await?
             }
-            Err(connection::Error::Closed) => return Ok(()),
+            Err(connection::Error::Closed(_)) => return Ok(()),
             Err(e) => return Err(e.into())
         }
     }
@@ -97,4 +97,3 @@ fn new_client(socket: TcpStream, path: &str) -> handshake::Client<'_, BufReader<
     client.add_extension(Box::new(deflate));
     client
 }
-

--- a/examples/autobahn_server.rs
+++ b/examples/autobahn_server.rs
@@ -50,7 +50,7 @@ async fn main() -> Result<(), BoxedError> {
                         break
                     }
                 }
-                Err(connection::Error::Closed) => break,
+                Err(connection::Error::Closed(_)) => break,
                 Err(e) => {
                     log::error!("connection error: {}", e);
                     break
@@ -74,4 +74,3 @@ fn new_server<'a>(socket: TcpStream) -> handshake::Server<'a, BufReader<BufWrite
     server.add_extension(Box::new(deflate));
     server
 }
-

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -373,7 +373,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Receiver<T> {
                 let (mut header, reason) = close_answer(&self.ctrl_buffer)?;
                 // Write back a Close frame
                 let mut unused = Vec::new();
-                if let Some(CloseReason { code, ..} ) = reason {
+                if let Some(CloseReason { code, .. }) = reason {
                     let mut data = code.to_be_bytes();
                     let mut data = Storage::Unique(&mut data);
                     write(self.id, self.mode, &mut self.codec, &mut self.writer, &mut header, &mut data, &mut unused).await?


### PR DESCRIPTION
When a remote sends us a `CLOSE` message it may contain a [reason code](https://tools.ietf.org/html/rfc6455#section-7.4.1) and ["application data" with further details](https://tools.ietf.org/html/rfc6455#section-5.5.1) about why the connection was closed.

Before this PR there was no way for applications using `soketto` to know what the code/data was sent from the remote.

Further context [here](https://github.com/libp2p/rust-libp2p/issues/2021).