### PR TITLE
Update deps and remove unnecessary transients

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,17 +14,18 @@ edition = "2018"
 all-features = true
 
 [features]
+default = []
 deflate = ["flate2"]
 
 [dependencies]
-base64 = "0.12"
-bytes = "0.5"
-flate2 = { version = "1.0.13", features = ["zlib"], default-features = false, optional = true }
-futures = { version = "0.3.1", features = ["unstable", "bilock"] }
-httparse = "1.3.4"
-log = "0.4.8"
-rand = "0.7"
-sha-1 = "0.9"
+base64 = { default-features = false, features = ["alloc"], version = "0.13" }
+bytes = { default-features = false, version = "1.0" }
+flate2 = { default-features = false, features = ["zlib"], optional = true, version = "1.0.13" }
+futures = { default-features = false, features = ["bilock", "std", "unstable"], version = "0.3.1" }
+httparse = { default-features = false, features = ["std"], version = "1.3.4" }
+log = { default-features = false, version = "0.4.8" }
+rand = { default-features = false, features = ["std", "std_rng"], version = "0.8" }
+sha-1 = { default-features = false, version = "0.9" }
 
 [dev-dependencies]
 quickcheck = "0.9"


### PR DESCRIPTION
All tests are passing.

* `cargo build` went down from `61` to `45` crates.

* Updates base64, bytes and rand to latest versions
