### PR TITLE
Handle CLOSE reason as Incoming

### DIFF
--- a/examples/autobahn_client.rs
+++ b/examples/autobahn_client.rs
@@ -68,7 +68,7 @@ async fn run_case(n: usize) -> Result<(), BoxedError> {
                 sender.send_text(std::str::from_utf8(&message)?).await?;
                 sender.flush().await?
             }
-            Err(connection::Error::Closed) => return Ok(()),
+            Err(connection::Error::Closed(_)) => return Ok(()),
             Err(e) => return Err(e.into())
         }
     }
@@ -97,4 +97,3 @@ fn new_client(socket: TcpStream, path: &str) -> handshake::Client<'_, BufReader<
     client.add_extension(Box::new(deflate));
     client
 }
-

--- a/examples/autobahn_client.rs
+++ b/examples/autobahn_client.rs
@@ -68,7 +68,7 @@ async fn run_case(n: usize) -> Result<(), BoxedError> {
                 sender.send_text(std::str::from_utf8(&message)?).await?;
                 sender.flush().await?
             }
-            Err(connection::Error::Closed(_)) => return Ok(()),
+            Err(connection::Error::Closed) => return Ok(()),
             Err(e) => return Err(e.into())
         }
     }

--- a/examples/autobahn_server.rs
+++ b/examples/autobahn_server.rs
@@ -50,7 +50,7 @@ async fn main() -> Result<(), BoxedError> {
                         break
                     }
                 }
-                Err(connection::Error::Closed) => break,
+                Err(connection::Error::Closed(_)) => break,
                 Err(e) => {
                     log::error!("connection error: {}", e);
                     break
@@ -74,4 +74,3 @@ fn new_server<'a>(socket: TcpStream) -> handshake::Server<'a, BufReader<BufWrite
     server.add_extension(Box::new(deflate));
     server
 }
-

--- a/examples/autobahn_server.rs
+++ b/examples/autobahn_server.rs
@@ -50,7 +50,7 @@ async fn main() -> Result<(), BoxedError> {
                         break
                     }
                 }
-                Err(connection::Error::Closed(_)) => break,
+                Err(connection::Error::Closed) => break,
                 Err(e) => {
                     log::error!("connection error: {}", e);
                     break

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -417,7 +417,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Receiver<T> {
 
     /// Flush the socket buffer.
     async fn flush(&mut self) -> Result<(), Error> {
-        log::trace!("{}: flushing connection (Receiver::flush())", self.id);
+        log::trace!("{}: Receiver flushing connection", self.id);
         if self.is_closed {
             return Ok(())
         }
@@ -461,7 +461,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Sender<T> {
 
     /// Flush the socket buffer.
     pub async fn flush(&mut self) -> Result<(), Error> {
-        log::trace!("{}: flushing connection (Sender::flush())", self.id);
+        log::trace!("{}: Sender flushing connection", self.id);
         self.writer.lock().await.flush().await.or(Err(Error::Closed))
     }
 
@@ -616,8 +616,7 @@ impl fmt::Display for Error {
                 write!(f, "utf-8 error: {}", e),
             Error::MessageTooLarge { current, maximum } =>
                 write!(f, "message too large: len >= {}, maximum = {}", current, maximum),
-            Error::Closed =>
-                write!(f, "connection closed")
+            Error::Closed => f.write_str("connection closed")
         }
     }
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -373,7 +373,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Receiver<T> {
                 let (mut header, reason) = close_answer(&self.ctrl_buffer)?;
                 // Write back a Close frame
                 let mut unused = Vec::new();
-                if let Some(CloseReason { code, ..} ) = reason {
+                if let Some(CloseReason { code, .. }) = reason {
                     let mut data = code.to_be_bytes();
                     let mut data = Storage::Unique(&mut data);
                     write(self.id, self.mode, &mut self.codec, &mut self.writer, &mut header, &mut data, &mut unused).await?

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -378,10 +378,10 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Receiver<T> {
                 if let Some(CloseReason { code, .. }) = reason {
                     let mut data = code.to_be_bytes();
                     let mut data = Storage::Unique(&mut data);
-                    write(self.id, self.mode, &mut self.codec, &mut self.writer, &mut header, &mut data, &mut unused).await?
+                    let _ = write(self.id, self.mode, &mut self.codec, &mut self.writer, &mut header, &mut data, &mut unused).await;
                 } else {
                     let mut data = Storage::Unique(&mut []);
-                    write(self.id, self.mode, &mut self.codec, &mut self.writer, &mut header, &mut data, &mut unused).await?
+                    let _ = write(self.id, self.mode, &mut self.codec, &mut self.writer, &mut header, &mut data, &mut unused).await;
                 }
                 self.flush().await?;
                 self.writer.lock().await.close().await?;

--- a/src/data.rs
+++ b/src/data.rs
@@ -10,13 +10,17 @@
 
 use std::{convert::TryFrom, fmt};
 
+use crate::connection::CloseReason;
+
 /// Data received from the remote end.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Incoming<'a> {
     /// Text or binary data.
     Data(Data),
     /// Data sent with a PONG control frame.
-    Pong(&'a [u8])
+    Pong(&'a [u8]),
+    /// The other end closed the connection.
+    Closed(CloseReason),
 }
 
 impl Incoming<'_> {
@@ -48,11 +52,22 @@ impl Incoming<'_> {
         }
     }
 
+    /// Is this a CLOSE frame?
+    // TODO: return `Option<CloseReason>`? Is this even needed?
+    pub fn is_close(&self) -> bool {
+        if let Incoming::Closed(_) = self {
+            true
+        } else {
+            false
+        }
+    }
+
     /// The length of data (number of bytes).
     pub fn len(&self) -> usize {
         match self {
             Incoming::Data(d) => d.len(),
-            Incoming::Pong(d) => d.len()
+            Incoming::Pong(d) => d.len(),
+            Incoming::Closed(reason) => std::mem::size_of_val(reason), // TODO: this makes no sense; use `unimplemented!()` here?
         }
     }
 }
@@ -118,4 +133,3 @@ impl AsRef<[u8]> for ByteSlice125<'_> {
         self.0
     }
 }
-

--- a/src/data.rs
+++ b/src/data.rs
@@ -51,25 +51,6 @@ impl Incoming<'_> {
             false
         }
     }
-
-    /// Is this a CLOSE frame?
-    // TODO: return `Option<CloseReason>`? Is this even needed?
-    pub fn is_close(&self) -> bool {
-        if let Incoming::Closed(_) = self {
-            true
-        } else {
-            false
-        }
-    }
-
-    /// The length of data (number of bytes).
-    pub fn len(&self) -> usize {
-        match self {
-            Incoming::Data(d) => d.len(),
-            Incoming::Pong(d) => d.len(),
-            Incoming::Closed(reason) => std::mem::size_of_val(reason), // TODO: this makes no sense; use `unimplemented!()` here?
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]


### PR DESCRIPTION
When a remote sends us a CLOSE message it may contain a reason code and "application data" with further details about why the connection was closed.

Before this PR there was no way for applications using `soketto` to know what the code/data was sent from the remote.

Further context [here](https://github.com/libp2p/rust-libp2p/issues/2021).


This is an alternative to #29 and returns the close reason as `Incoming::Closed` instead of `Error::Closed(reason)`.