### PR TITLE
[client handshake]: send `Connection: Upgrade`

### DIFF
--- a/src/handshake/client.rs
+++ b/src/handshake/client.rs
@@ -142,7 +142,7 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Client<'a, T> {
         self.buffer.extend_from_slice(b" HTTP/1.1");
         self.buffer.extend_from_slice(b"\r\nHost: ");
         self.buffer.extend_from_slice(self.host.as_bytes());
-        self.buffer.extend_from_slice(b"\r\nUpgrade: websocket\r\nConnection: upgrade");
+        self.buffer.extend_from_slice(b"\r\nUpgrade: websocket\r\nConnection: Upgrade");
         self.buffer.extend_from_slice(b"\r\nSec-WebSocket-Key: ");
         self.buffer.extend_from_slice(&self.nonce[.. self.nonce_offset]);
         if let Some(o) = &self.origin {


### PR DESCRIPTION
I found an edge-case where a server refused the handshake based on that
soketto was sending `Connection: upgrade` instead of `Connection: Upgrade`.

See https://datatracker.ietf.org/doc/html/rfc6455#section-1.2 for further info.