### PR TITLE
Expose zero-copy-ish headers on ClientRequest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ default = []
 deflate = ["flate2"]
 
 [dependencies]
+arrayvec = { default-features = false, version = "0.7.1" }
 base64 = { default-features = false, features = ["alloc"], version = "0.13" }
 bytes = { default-features = false, version = "1.0" }
 flate2 = { default-features = false, features = ["zlib"], optional = true, version = "1.0.13" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ default = []
 deflate = ["flate2"]
 
 [dependencies]
-arrayvec = { default-features = false, version = "0.7.1" }
 base64 = { default-features = false, features = ["alloc"], version = "0.13" }
 bytes = { default-features = false, version = "1.0" }
 flate2 = { default-features = false, features = ["zlib"], optional = true, version = "1.0.13" }

--- a/examples/autobahn_server.rs
+++ b/examples/autobahn_server.rs
@@ -16,7 +16,7 @@
 
 use futures::io::{BufReader, BufWriter};
 use soketto::{BoxedError, connection, handshake};
-use tokio::{net::{TcpListener, TcpStream}};
+use tokio::net::{TcpListener, TcpStream};
 use tokio_util::compat::{Compat, TokioAsyncReadCompatExt};
 use tokio_stream::{wrappers::TcpListenerStream, StreamExt};
 #[tokio::main]
@@ -27,9 +27,9 @@ async fn main() -> Result<(), BoxedError> {
         let mut server = new_server(socket?);
         let key = {
             let req = server.receive_request().await?;
-            req.into_key()
+            req.key()
         };
-        let accept = handshake::server::Response::Accept { key: &key, protocol: None };
+        let accept = handshake::server::Response::Accept { key, protocol: None };
         server.send_response(&accept).await?;
         let (mut sender, mut receiver) = server.into_builder().finish();
         let mut message = Vec::new();

--- a/examples/autobahn_server.rs
+++ b/examples/autobahn_server.rs
@@ -26,11 +26,11 @@ async fn main() -> Result<(), BoxedError> {
     while let Some(socket) = incoming.next().await {
         let mut server = new_server(socket?);
         let key = {
-            let req = server.receive_request().await?; // READS STUFF INTO BUFFER UNTIL HEADERS CAN BE PARSED
+            let req = server.receive_request().await?;
             req.into_key()
         };
         let accept = handshake::server::Response::Accept { key: &key, protocol: None };
-        server.send_response(&accept).await?; // WIPES INTERNAL BUFFER TO USE IT TO CONSTRUCT THE RESPONSE
+        server.send_response(&accept).await?;
         let (mut sender, mut receiver) = server.into_builder().finish();
         let mut message = Vec::new();
         loop {

--- a/examples/autobahn_server.rs
+++ b/examples/autobahn_server.rs
@@ -26,11 +26,11 @@ async fn main() -> Result<(), BoxedError> {
     while let Some(socket) = incoming.next().await {
         let mut server = new_server(socket?);
         let key = {
-            let req = server.receive_request().await?;
+            let req = server.receive_request().await?; // READS STUFF INTO BUFFER UNTIL HEADERS CAN BE PARSED
             req.into_key()
         };
         let accept = handshake::server::Response::Accept { key: &key, protocol: None };
-        server.send_response(&accept).await?;
+        server.send_response(&accept).await?; // WIPES INTERNAL BUFFER TO USE IT TO CONSTRUCT THE RESPONSE
         let (mut sender, mut receiver) = server.into_builder().finish();
         let mut message = Vec::new();
         loop {

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -135,7 +135,7 @@ pub enum Error {
     UnsupportedHttpVersion,
     /// An incomplete HTTP request.
     IncompleteHttpRequest,
-    /// The value of the `Sec-WebSocket-Key` header is too long
+    /// The value of the `Sec-WebSocket-Key` header is of unexpected length.
     SecWebSocketKeyInvalidLength(usize),
     /// The handshake request was not a GET request.
     InvalidRequestMethod,

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -133,6 +133,10 @@ pub enum Error {
     Io(io::Error),
     /// An HTTP version =/= 1.1 was encountered.
     UnsupportedHttpVersion,
+    /// An incomplete HTTP request.
+    IncompleteHttpRequest,
+    /// The value of the `Sec-WebSocket-Key` header is too long
+    SecWebsocketKeyTooLong,
     /// The handshake request was not a GET request.
     InvalidRequestMethod,
     /// An HTTP header has not been present.
@@ -160,6 +164,10 @@ impl fmt::Display for Error {
                 write!(f, "i/o error: {}", e),
             Error::UnsupportedHttpVersion =>
                 f.write_str("http version was not 1.1"),
+            Error::IncompleteHttpRequest =>
+                f.write_str("http request was incomplete"),
+            Error::SecWebsocketKeyTooLong =>
+                f.write_str("Sec-WebSocket-Key header is too long"),
             Error::InvalidRequestMethod =>
                 f.write_str("handshake was not a GET request"),
             Error::HeaderNotFound(name) =>
@@ -190,6 +198,8 @@ impl std::error::Error for Error {
             Error::Http(e) => Some(&**e),
             Error::Utf8(e) => Some(e),
             Error::UnsupportedHttpVersion
+            | Error::IncompleteHttpRequest
+            | Error::SecWebsocketKeyTooLong
             | Error::InvalidRequestMethod
             | Error::HeaderNotFound(_)
             | Error::UnexpectedHeader(_)

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -227,11 +227,13 @@ impl From<str::Utf8Error> for Error {
 ///
 /// Per [RFC 6455](https://datatracker.ietf.org/doc/html/rfc6455#section-4.1):
 ///
-/// > (...) The value of this header field MUST be a
-/// > nonce consisting of a randomly selected 16-byte value that has
-/// > been base64-encoded (see Section 4 of [RFC4648]).
+/// ```text
+/// (...) The value of this header field MUST be a
+/// nonce consisting of a randomly selected 16-byte value that has
+/// been base64-encoded (see Section 4 of [RFC4648]). (...)
+/// ```
 ///
-/// base64 encoded 16-byte nonce with padding is always 24 bytes long.
+/// Base64 encoding of the nonce produces 24 ASCII bytes, padding included.
 pub type WebSocketKey = [u8; 24];
 
 #[cfg(test)]

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -136,7 +136,7 @@ pub enum Error {
     /// An incomplete HTTP request.
     IncompleteHttpRequest,
     /// The value of the `Sec-WebSocket-Key` header is too long
-    SecWebsocketKeyInvalidLength(usize),
+    SecWebSocketKeyInvalidLength(usize),
     /// The handshake request was not a GET request.
     InvalidRequestMethod,
     /// An HTTP header has not been present.
@@ -166,7 +166,7 @@ impl fmt::Display for Error {
                 f.write_str("http version was not 1.1"),
             Error::IncompleteHttpRequest =>
                 f.write_str("http request was incomplete"),
-            Error::SecWebsocketKeyInvalidLength(len) =>
+            Error::SecWebSocketKeyInvalidLength(len) =>
                 write!(f, "Sec-WebSocket-Key header was {} bytes longth, expected 24", len),
             Error::InvalidRequestMethod =>
                 f.write_str("handshake was not a GET request"),
@@ -199,7 +199,7 @@ impl std::error::Error for Error {
             Error::Utf8(e) => Some(e),
             Error::UnsupportedHttpVersion
             | Error::IncompleteHttpRequest
-            | Error::SecWebsocketKeyInvalidLength(_)
+            | Error::SecWebSocketKeyInvalidLength(_)
             | Error::InvalidRequestMethod
             | Error::HeaderNotFound(_)
             | Error::UnexpectedHeader(_)

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -256,7 +256,7 @@ pub struct ClientRequest<'a> {
 }
 
 /// Select HTTP headers sent by the client.
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub struct RequestHeaders<'a> {
     /// The [`Host`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host) header.
     pub host: &'a [u8],
@@ -280,8 +280,8 @@ impl<'a> ClientRequest<'a> {
         self.path
     }
 
-    pub fn headers(&self) -> &RequestHeaders {
-        &self.headers
+    pub fn headers(&self) -> RequestHeaders {
+        self.headers
     }
 }
 

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -175,7 +175,7 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Server<'a, T> {
         let ws_key = with_first_header(&request.headers, "Sec-WebSocket-Key", |k| {
             use std::convert::TryFrom;
 
-            WebSocketKey::try_from(k).map_err(|_| Error::SecWebsocketKeyInvalidLength(k.len()))
+            WebSocketKey::try_from(k).map_err(|_| Error::SecWebSocketKeyInvalidLength(k.len()))
         })?;
 
         for h in request.headers.iter()

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -173,14 +173,9 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Server<'a, T> {
         let headers = RequestHeaders { host, origin };
 
         let ws_key = with_first_header(&request.headers, "Sec-WebSocket-Key", |k| {
-            if k.len() != 24 {
-                return Err(Error::SecWebsocketKeyInvalidLength(k.len()));
-            }
-            let mut key = [0; 24];
+            use std::convert::TryFrom;
 
-            key.copy_from_slice(k);
-
-            Ok(key)
+            WebSocketKey::try_from(k).map_err(|_| Error::SecWebsocketKeyInvalidLength(k.len()))
         })?;
 
         for h in request.headers.iter()

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -128,7 +128,7 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Server<'a, T> {
     }
 
     // Decode client handshake request.
-    fn decode_request<'r>(&'r mut self) -> Result<ClientRequest<'r>, Error> {
+    fn decode_request(&mut self) -> Result<ClientRequest, Error> {
         let mut header_buf = [httparse::EMPTY_HEADER; MAX_NUM_HEADERS];
         let mut request = httparse::Request::new(&mut header_buf);
 

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -44,9 +44,6 @@ pub struct Server<'a, T> {
     buffer: BytesMut
 }
 
-/// Owned value of the `Sec-WebSocket-Key` header.
-pub type WebSocketKey = ArrayVec<u8, 28>;
-
 impl<'a, T: AsyncRead + AsyncWrite + Unpin> Server<'a, T> {
     /// Create a new server handshake.
     pub fn new(socket: T) -> Self {
@@ -164,7 +161,7 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Server<'a, T> {
         let headers = RequestHeaders { host, origin };
 
         let ws_key = with_first_header(&request.headers, "Sec-WebSocket-Key", |k| {
-            let mut key = ArrayVec::new();
+            let mut key = WebSocketKey::new();
 
             match key.try_extend_from_slice(k) {
                 Ok(()) => Ok(key),
@@ -234,6 +231,9 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Server<'a, T> {
         }
     }
 }
+
+/// Owned value of the `Sec-WebSocket-Key` header.
+pub type WebSocketKey = ArrayVec<u8, 28>;
 
 /// Handshake request received from the client.
 #[derive(Debug)]

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -265,7 +265,7 @@ pub struct RequestHeaders<'a> {
 }
 
 impl<'a> ClientRequest<'a> {
-    /// A reference to the nonce.
+    /// The `Sec-WebSocket-Key` header nonce value.
     pub fn key(&self) -> WebSocketKey {
         self.ws_key
     }

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -86,7 +86,7 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Server<'a, T> {
     }
 
     /// Await an incoming client handshake request.
-    pub async fn receive_request<'r>(&'r mut self) -> Result<ClientRequest<'r>, Error> {
+    pub async fn receive_request(&mut self) -> Result<ClientRequest<'_>, Error> {
         self.buffer.clear();
 
         let mut skip = 0;

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -157,7 +157,7 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Server<'a, T> {
             return Err(Error::UnsupportedHttpVersion)
         }
 
-        let host = with_first_header(&request.headers, "Host", |h| Ok(h))?;
+        let host = with_first_header(&request.headers, "Host", Ok)?;
 
         expect_ascii_header(request.headers, "Upgrade", "websocket")?;
         expect_ascii_header(request.headers, "Connection", "upgrade")?;

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -98,7 +98,8 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Server<'a, T> {
                 break;
             }
 
-            // Skip bytes that did not contain CRLF in the next iteration
+            // Skip bytes that did not contain CRLF in the next iteration.
+            // If we only read a partial CRLF sequence, we would miss it if we skipped the full buffer length, hence backing off the full 4 bytes.
             skip = self.buffer.len().saturating_sub(4);
         }
 

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -98,7 +98,7 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Server<'a, T> {
 
             // We don't expect body, so can search for the CRLF headers tail from
             // the end of the buffer.
-            if self.buffer[skip..limit].windows(4).rev().find(|w| w == b"\r\n\r\n").is_some() {
+            if self.buffer[skip..limit].windows(4).rev().any(|w| w == b"\r\n\r\n") {
                 break;
             }
 

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -148,7 +148,7 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Server<'a, T> {
             return Err(Error::UnsupportedHttpVersion)
         }
 
-        let host = with_first_header(&request.headers, "Host", |h| Ok(header_to_str(h)))?;
+        let host = with_first_header(&request.headers, "Host", |h| Ok(h))?;
 
         expect_ascii_header(request.headers, "Upgrade", "websocket")?;
         expect_ascii_header(request.headers, "Connection", "upgrade")?;
@@ -156,7 +156,7 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Server<'a, T> {
 
         let origin = request.headers.iter().find_map(|h| {
             if h.name.eq_ignore_ascii_case("Origin") {
-                Some(header_to_str(h.value))
+                Some(h.value)
             } else {
                 None
             }
@@ -235,10 +235,6 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Server<'a, T> {
     }
 }
 
-fn header_to_str(bytes: &[u8]) -> &str {
-    str::from_utf8(bytes).unwrap_or("INVALID_UTF8")
-}
-
 /// Handshake request received from the client.
 #[derive(Debug)]
 pub struct ClientRequest<'a> {
@@ -252,9 +248,9 @@ pub struct ClientRequest<'a> {
 #[derive(Debug)]
 pub struct RequestHeaders<'a> {
     /// The [`Host`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host) header.
-    pub host: &'a str,
+    pub host: &'a [u8],
     /// The [`Origin`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin) header, if provided.
-    pub origin: Option<&'a str>,
+    pub origin: Option<&'a [u8]>,
 }
 
 impl<'a> ClientRequest<'a> {

--- a/src/handshake/server.rs
+++ b/src/handshake/server.rs
@@ -275,6 +275,7 @@ impl<'a> ClientRequest<'a> {
         self.path
     }
 
+    /// Select HTTP headers sent by the client.
     pub fn headers(&self) -> RequestHeaders {
         self.headers
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,11 +76,11 @@
 //!
 //!     let websocket_key = {
 //!         let req = server.receive_request().await?;
-//!         req.into_key()
+//!         req.key()
 //!     };
 //!
 //!     // Here we accept the client unconditionally.
-//!     let accept = Response::Accept { key: &websocket_key, protocol: None };
+//!     let accept = Response::Accept { key: websocket_key, protocol: None };
 //!     server.send_response(&accept).await?;
 //!
 //!     // And we can finally transition to a websocket connection.


### PR DESCRIPTION
Alternative to #34.

I hope @tomaka can appreciate the number of hoops I had to jump through to get this to work properly. The way headers were previously parsed totally screwed with lifetimes here and prevented zero-copy header exposure (also the reason why `path` was previously an owned `String`).

What made this possible is realization that WebSocket handshake request does not contain body, thus we can safely borrow stuff from the buffer until a response needs to be sent (at which point buffer is cleared regardless).

Side effect: removed two allocations from request handling, not that it was a bottleneck, but hey.

**BREAKING CHANGES:**

+ `ClientRequest::path()` will default to `"\"` if omitted in request (was empty string).
+ `ClientRequest::key()` now returns `WebSocketKey` (alias of `[u8; 24]`), was `&[u8]`.
+ `ClientRequest::into_key()` is gone.
+ `Response::Accept`'s `key` field is now `WebSocketKey` (alias of `[u8; 24]`), was `&[u8]`.
+ `handshake::Error` has new variants.
+ `Server::receive_request()` will only attempt to read headers up to 8KiB.

**ADDED**

+ `ClientRequest::headers()` returns a new `RequestHeaders` struct with `host` and `origin` fields, exposing the `Host` and `Origin` header values (`&[u8]` and `Option<&[u8]>` respectively).