### PR TITLE
Server::send_text_owned

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -434,8 +434,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Sender<T> {
 
     /// Send a text value over the websocket connection.
     ///
-    /// In contrast to [`Sender::send_text`] the provided data is modified
-    /// in-place, e.g. if masking is necessary.
+    /// This method performs one fewer copy than [`Sender::send_text`].
     pub async fn send_text_owned(&mut self, data: String) -> Result<(), Error> {
         let mut header = Header::new(OpCode::Text);
         self.send_frame(&mut header, &mut Storage::Owned(data.into_bytes())).await
@@ -449,8 +448,8 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Sender<T> {
 
     /// Send some binary data over the websocket connection.
     ///
-    /// In contrast to [`Sender::send_binary`] the provided data is modified
-    /// in-place, e.g. if masking is necessary.
+    /// This method performs one fewer copy than [`Sender::send_binary`].
+    /// The `data` buffer may be modified by this method, e.g. if masking is necessary.
     pub async fn send_binary_mut(&mut self, mut data: impl AsMut<[u8]>) -> Result<(), Error> {
         let mut header = Header::new(OpCode::Binary);
         self.send_frame(&mut header, &mut Storage::Unique(data.as_mut())).await

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -432,6 +432,15 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Sender<T> {
         self.send_frame(&mut header, &mut Storage::Shared(data.as_ref().as_bytes())).await
     }
 
+    /// Send a text value over the websocket connection.
+    ///
+    /// In contrast to [`Sender::send_text`] the provided data is modified
+    /// in-place, e.g. if masking is necessary.
+    pub async fn send_text_owned(&mut self, data: String) -> Result<(), Error> {
+        let mut header = Header::new(OpCode::Text);
+        self.send_frame(&mut header, &mut Storage::Owned(data.into_bytes())).await
+    }
+
     /// Send some binary data over the websocket connection.
     pub async fn send_binary(&mut self, data: impl AsRef<[u8]>) -> Result<(), Error> {
         let mut header = Header::new(OpCode::Binary);

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -434,7 +434,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Sender<T> {
 
     /// Send a text value over the websocket connection.
     ///
-    /// This method performs one fewer copy than [`Sender::send_text`].
+    /// This method performs one copy fewer than [`Sender::send_text`].
     pub async fn send_text_owned(&mut self, data: String) -> Result<(), Error> {
         let mut header = Header::new(OpCode::Text);
         self.send_frame(&mut header, &mut Storage::Owned(data.into_bytes())).await
@@ -448,7 +448,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Sender<T> {
 
     /// Send some binary data over the websocket connection.
     ///
-    /// This method performs one fewer copy than [`Sender::send_binary`].
+    /// This method performs one copy fewer than [`Sender::send_binary`].
     /// The `data` buffer may be modified by this method, e.g. if masking is necessary.
     pub async fn send_binary_mut(&mut self, mut data: impl AsMut<[u8]>) -> Result<(), Error> {
         let mut header = Header::new(OpCode::Binary);


### PR DESCRIPTION
This is somewhat analogous to `send_binary_mut` in that it allows us to do masking in place, which is one less copy for [jsonrpsee](https://github.com/paritytech/jsonrpsee/pull/374).

Doing `send_text_mut` would be a closer mirror, but casting `&mut str` into `&mut [u8]` is unsafe (the original `str` slice might end up not being valid utf8). Soketto already supports owned buffers internally though, and since jsonrpsee spits out owned `String`s, we can use that to make responses that one memcpy faster.