### PR TITLE
Release v0.7.0 (to develop, not master.. whoops)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## 0.7.0
+
+- [added] Added the `handshake::http` module and example usage at `examples/hyper_server.rs` to make using Soketto in conjunction with libraries that use the `http` types (like Hyper) simpler [#45](https://github.com/paritytech/soketto/pull/45) [#48](https://github.com/paritytech/soketto/pull/48)
+- [added] Allow setting custom headers on the client to be sent to WebSocket servers when the opening handshake is performed [#47](https://github.com/paritytech/soketto/pull/47)
+
 ## 0.6.0
 
 - [changed] Expose the `Origin` headers from the client handshake on `ClientRequest` [#35](https://github.com/paritytech/soketto/pull/35)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soketto"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Parity Technologies <admin@parity.io>", "Jason Ozias <jason.g.ozias@gmail.com>"]
 description = "A websocket protocol implementation."
 keywords = ["websocket", "codec", "async", "futures"]

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,7 +11,7 @@ These steps assume that you've checked out the Soketto repository and are in the
 3.  Check that you're happy with the current documentation.
 
     ```
-    cargo doc --open
+    cargo doc --open --all-features
     ```
 
     CI checks for broken internal links at the moment. Optionally you can also confirm that any external links
@@ -19,7 +19,7 @@ These steps assume that you've checked out the Soketto repository and are in the
 
     ```
     cargo install cargo-deadlinks
-    cargo deadlinks --check-http
+    cargo deadlinks --check-http -- --all-features
     ```
 
     If there are minor issues with the documentation, they can be fixed in the release branch.


### PR DESCRIPTION
- [added] Added the `handshake::http` module and example usage at `examples/hyper_server.rs` to make using Soketto in conjunction with libraries that use the `http` types (like Hyper) simpler [#45](https://github.com/paritytech/soketto/pull/45) [#48](https://github.com/paritytech/soketto/pull/48)
- [added] Allow setting custom headers on the client to be sent to WebSocket servers when the opening handshake is performed [#47](https://github.com/paritytech/soketto/pull/47)

Also tweak docs a little as part of this PR 