### PR TITLE
expose all HTTP headers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ httparse = { default-features = false, features = ["std"], version = "1.3.4" }
 log = { default-features = false, version = "0.4.8" }
 rand = { default-features = false, features = ["std", "std_rng"], version = "0.8" }
 sha-1 = { default-features = false, version = "0.9" }
-http = { default-features = false, version = "0.2", optional = true }
+http = { default-features = false, version = "0.2" }
 
 [dev-dependencies]
 quickcheck = "0.9"

--- a/README.md
+++ b/README.md
@@ -6,4 +6,3 @@ This crate is a heavily modified fork of the [twist][3] crate.
 [1]: https://tools.ietf.org/html/rfc6455
 [2]: https://crates.io/crates/tokio-codec
 [3]: https://crates.io/crates/twist
-

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -11,7 +11,6 @@
 //! [handshake]: https://tools.ietf.org/html/rfc6455#section-4
 
 pub mod client;
-#[cfg(feature = "http")]
 pub mod http;
 pub mod server;
 


### PR DESCRIPTION
I'm not sure about how much overhead the allocations in `HeaderMap` will cause.