### PR TITLE
base64 0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default = []
 deflate = ["flate2"]
 
 [dependencies]
-base64 = { default-features = false, features = ["alloc"], version = "0.13" }
+base64 = { default-features = false, features = ["alloc"], version = "0.21" }
 bytes = { default-features = false, version = "1.0" }
 flate2 = { default-features = false, features = ["zlib"], optional = true, version = "1.0.13" }
 futures = { default-features = false, features = ["bilock", "std", "unstable"], version = "0.3.1" }

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -149,7 +149,9 @@ fn generate_accept_key<'k>(key_base64: &WebSocketKey) -> [u8; 28] {
 	let d = digest.finalize();
 
 	let mut output_buf = [0; 28];
-	let n = base64::engine::general_purpose::STANDARD.encode_slice(d, &mut output_buf).unwrap();
+	let n = base64::engine::general_purpose::STANDARD
+		.encode_slice(d, &mut output_buf)
+		.expect("encoding to base64 is exactly 28 bytes; qed");
 	debug_assert_eq!(n, 28, "encoding to base64 should be exactly 28 bytes");
 	output_buf
 }

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -16,6 +16,7 @@ pub mod http;
 pub mod server;
 
 use crate::extension::{Extension, Param};
+use base64::Engine;
 use bytes::BytesMut;
 use sha1::{Digest, Sha1};
 use std::{fmt, io, str};
@@ -148,7 +149,7 @@ fn generate_accept_key<'k>(key_base64: &WebSocketKey) -> [u8; 28] {
 	let d = digest.finalize();
 
 	let mut output_buf = [0; 28];
-	let n = base64::encode_config_slice(&d, base64::STANDARD, &mut output_buf);
+	let n = base64::engine::general_purpose::STANDARD.encode_slice(d, &mut output_buf).unwrap();
 	debug_assert_eq!(n, 28, "encoding to base64 should be exactly 28 bytes");
 	output_buf
 }

--- a/src/handshake/client.rs
+++ b/src/handshake/client.rs
@@ -131,7 +131,9 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Client<'a, T> {
 	/// Encode the client handshake as a request, ready to be sent to the server.
 	fn encode_request(&mut self) {
 		let nonce: [u8; 16] = rand::random();
-		base64::engine::general_purpose::STANDARD.encode_slice(nonce, &mut self.nonce).unwrap();
+		base64::engine::general_purpose::STANDARD
+			.encode_slice(nonce, &mut self.nonce)
+			.expect("encoding to base64 is exactly 16 bytes; qed");
 		self.buffer.extend_from_slice(b"GET ");
 		self.buffer.extend_from_slice(self.resource.as_bytes());
 		self.buffer.extend_from_slice(b" HTTP/1.1");

--- a/src/handshake/client.rs
+++ b/src/handshake/client.rs
@@ -16,6 +16,7 @@ use super::{
 };
 use crate::connection::{self, Mode};
 use crate::{extension::Extension, Parsing};
+use base64::Engine;
 use bytes::{Buf, BytesMut};
 use futures::prelude::*;
 use sha1::{Digest, Sha1};
@@ -130,7 +131,7 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Client<'a, T> {
 	/// Encode the client handshake as a request, ready to be sent to the server.
 	fn encode_request(&mut self) {
 		let nonce: [u8; 16] = rand::random();
-		base64::encode_config_slice(&nonce, base64::STANDARD, &mut self.nonce);
+		base64::engine::general_purpose::STANDARD.encode_slice(nonce, &mut self.nonce).unwrap();
 		self.buffer.extend_from_slice(b"GET ");
 		self.buffer.extend_from_slice(self.resource.as_bytes());
 		self.buffer.extend_from_slice(b" HTTP/1.1");
@@ -194,7 +195,7 @@ impl<'a, T: AsyncRead + AsyncWrite + Unpin> Client<'a, T> {
 			let mut digest = Sha1::new();
 			digest.update(&self.nonce);
 			digest.update(KEY);
-			let ours = base64::encode(&digest.finalize());
+			let ours = base64::engine::general_purpose::STANDARD.encode(digest.finalize());
 			if ours.as_bytes() != theirs {
 				return Err(Error::InvalidSecWebSocketAccept);
 			}


### PR DESCRIPTION
encode_config_slice panicked if the slice was too short. It now returns an error. The added `unwrap`s maintain the prior API.