### PR TITLE
fix: ignore I/O error after close sent succesfully

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -415,7 +415,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Receiver<T> {
 					.await;
 				}
 				self.flush().await?;
-				// Close down the connection but the IO stream could already be closed and
+				// Close down the connection but the I/O stream could already be closed and
 				// we don't want propagate such error to the user if the IO was already closed.
 				_ = self.writer.lock().await.close().await;
 				self.is_closed = true;

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -416,7 +416,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Receiver<T> {
 				}
 				self.flush().await?;
 				// Close down the connection but the I/O stream could already be closed and
-				// we don't want propagate such error to the user if the IO was already closed.
+				// we don't want propagate such error to the user if the I/O was already closed.
 				_ = self.writer.lock().await.close().await;
 				self.is_closed = true;
 				Ok(reason)


### PR DESCRIPTION
This PR fixes that after the close reason has been sent soketto is trying to close down the I/O stream but it's possible that it's already closed down by the other end when it receives the close message.

So, after this change the actual websocket close message is prioritized and the actual I/O close status is ignored because once the websocket close reason is sent to the other side then it's regarded as clean shutdown.

### Behavior before this PR

```bash
2024-11-29T15:29:42.304445Z TRACE soketto::connection: f1671608: closing connection
2024-11-29T15:29:42.304454Z TRACE soketto::connection: f1671608: send: (Close (fin 1) (rsv 000) (mask (0 0)) (len 2))
2024-11-29T15:29:42.304458Z TRACE soketto::connection: f1671608: Sender flushing connection
2024-11-29T15:29:42.304490Z  INFO ws: Server stopped
2024-11-29T15:29:42.304498Z TRACE soketto: read 2 bytes
2024-11-29T15:29:42.304505Z TRACE soketto::connection: d076841f: recv: (Close (fin 1) (rsv 000) (mask (0 0)) (len 2))
2024-11-29T15:29:42.304510Z TRACE soketto::connection: d076841f: Acknowledging CLOSE to sender
2024-11-29T15:29:42.304513Z TRACE soketto::connection: d076841f: send: (Close (fin 1) (rsv 000) (mask (1 b1b8972d)) (len 2))
2024-11-29T15:29:42.304517Z TRACE soketto::connection: d076841f: Receiver flushing connection
2024-11-29T15:29:42.304541Z DEBUG jsonrpsee-client: Failed to read message: i/o error: Transport endpoint is not connected (os error 107)
2024-11-29T15:29:42.304557Z TRACE soketto::connection: d076841f: closing connection
2024-11-29T15:29:42.304560Z TRACE soketto::connection: d076841f: send: (Close (fin 1) (rsv 000) (mask (1 3e613906)) (len 2))
2024-11-29T15:29:42.304564Z TRACE soketto::connection: d076841f: Sender flushing connection
```

### Behavior after this PR

```bash
2024-11-29T15:28:13.523625Z TRACE soketto::connection: dfacd4a8: closing connection
2024-11-29T15:28:13.523630Z TRACE soketto::connection: dfacd4a8: send: (Close (fin 1) (rsv 000) (mask (0 0)) (len 2))
2024-11-29T15:28:13.523635Z TRACE soketto::connection: dfacd4a8: Sender flushing connection
2024-11-29T15:28:13.523666Z  INFO ws: Server stopped
2024-11-29T15:28:13.523846Z TRACE soketto: read 2 bytes
2024-11-29T15:28:13.523855Z TRACE soketto::connection: d0adc0df: recv: (Close (fin 1) (rsv 000) (mask (0 0)) (len 2))
2024-11-29T15:28:13.523860Z TRACE soketto::connection: d0adc0df: Acknowledging CLOSE to sender
2024-11-29T15:28:13.523867Z TRACE soketto::connection: d0adc0df: send: (Close (fin 1) (rsv 000) (mask (1 56089ba8)) (len 2))
2024-11-29T15:28:13.523871Z TRACE soketto::connection: d0adc0df: Receiver flushing connection
2024-11-29T15:28:13.523895Z TRACE soketto::connection: d0adc0df: recv, incoming CLOSE: CloseReason { code: 1000, descr: Some("") }
2024-11-29T15:28:13.523901Z DEBUG jsonrpsee-client: Failed to read message: The connection was closed: CloseReason { code: 1000, descr: Some("") }
2024-11-29T15:28:13.523913Z TRACE soketto::connection: d0adc0df: closing connection
2024-11-29T15:28:13.523916Z TRACE soketto::connection: d0adc0df: send: (Close (fin 1) (rsv 000) (mask (1 800d4abd)) (len 2))
2024-11-29T15:28:13.523920Z TRACE soketto::connection: d0adc0df: Sender flushing connection
```